### PR TITLE
merch UI: picker (#73, #74, #75), checkout (#76), order status (#79)

### DIFF
--- a/builder/templates/drawing.ts
+++ b/builder/templates/drawing.ts
@@ -47,6 +47,9 @@ export default function renderDrawing(v: DrawingView): string {
       <p>
         <a href="/?fork=${esc(v.id)}">fork this drawing</a>
       </p>
+      <p>
+        <a href="/merch?d=${esc(v.id)}&amp;frame=0" rel="nofollow noreferrer">make merch</a>
+      </p>
     </main>
     <footer>
       <a href="${esc(v.repo_url)}" target="_blank" rel="noopener">source on github</a>

--- a/infra/aws/template.yaml
+++ b/infra/aws/template.yaml
@@ -119,15 +119,21 @@ Resources:
         function handler(event) {
           var req = event.request;
           var uri = req.uri;
-          // /d/<64hex>           -> /d/<64hex>.html
-          // /days/YYYY-MM-DD/p/N -> /days/YYYY-MM-DD/p/N.html
-          // /gallery             -> /gallery.html
+          // /d/<64hex>                 -> /d/<64hex>.html
+          // /days/YYYY-MM-DD/p/N       -> /days/YYYY-MM-DD/p/N.html
+          // /gallery                   -> /gallery.html
+          // /merch                     -> /merch.html  (catalog picker SPA)
+          // /merch/order/<uuid>        -> /order.html  (order status SPA)
           if (/^\/d\/[0-9a-f]{64}$/.test(uri)) {
             req.uri = uri + ".html";
           } else if (/^\/days\/\d{4}-\d{2}-\d{2}\/p\/\d+$/.test(uri)) {
             req.uri = uri + ".html";
           } else if (uri === "/gallery") {
             req.uri = "/gallery.html";
+          } else if (uri === "/merch") {
+            req.uri = "/merch.html";
+          } else if (/^\/merch\/order\/[0-9a-f-]{36}$/.test(uri)) {
+            req.uri = "/order.html";
           }
           return req;
         }

--- a/merch.html
+++ b/merch.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Draw! · make merch</title>
+    <link rel="stylesheet" href="./src/style.css" />
+  </head>
+  <body class="merch-body">
+    <header>
+      <h1><a href="/">Draw!</a></h1>
+      <nav>
+        <a href="/gallery">gallery</a>
+      </nav>
+    </header>
+    <main class="merch-page">
+      <section class="merch-preview">
+        <canvas id="preview" aria-label="drawing preview"></canvas>
+        <div id="frameStrip" class="frame-strip" hidden></div>
+      </section>
+      <section class="merch-catalog">
+        <h2>pick a product</h2>
+        <div id="productGrid" class="product-grid"></div>
+        <div id="variantPicker" class="variant-picker" hidden></div>
+        <button id="checkoutBtn" type="button" disabled>continue to checkout</button>
+        <p id="status" class="merch-status"></p>
+      </section>
+    </main>
+    <footer>
+      <a href="https://github.com/potomak/drawbang" target="_blank" rel="noopener">source on github</a>
+    </footer>
+    <script type="module" src="./src/merch.ts"></script>
+  </body>
+</html>

--- a/merch/lambda.ts
+++ b/merch/lambda.ts
@@ -128,11 +128,14 @@ async function checkout(
   };
   await deps.orders.createOrder(order);
 
+  // The picker can't know the order id at request time, so it embeds the
+  // literal "{ORDER_ID}" placeholder. Substitute here before Stripe sees it.
+  const successUrl = body.success_url.replace("{ORDER_ID}", orderId);
   const session = await deps.stripe.createCheckoutSession({
     orderId,
     productName: variant.label,
     amountCents: variant.retail_cents,
-    successUrl: body.success_url,
+    successUrl,
     cancelUrl: body.cancel_url,
     ...(customerEmail ? { customerEmail } : {}),
     shippingCountries: deps.shippingCountries,

--- a/order.html
+++ b/order.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Draw! · order status</title>
+    <link rel="stylesheet" href="./src/style.css" />
+  </head>
+  <body class="merch-body">
+    <header>
+      <h1><a href="/">Draw!</a></h1>
+      <nav>
+        <a href="/gallery">gallery</a>
+      </nav>
+    </header>
+    <main class="order-page">
+      <h2>order status</h2>
+      <div id="orderCard" class="order-card">
+        <p id="status" class="merch-status">loading order…</p>
+      </div>
+    </main>
+    <footer>
+      <a href="https://github.com/potomak/drawbang" target="_blank" rel="noopener">source on github</a>
+    </footer>
+    <script type="module" src="./src/order.ts"></script>
+  </body>
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,7 @@ let frameBeforePlay = 0;
 let clipboard: Bitmap | null = null;
 const history = new History();
 let localId: string | null = null;
+let lastPublishedId: string | null = null;
 const PLAY_DELAY_MS = 200;
 
 // -- DOM setup --------------------------------------------------------------
@@ -109,6 +110,7 @@ app.innerHTML = /* html */ `
       <button data-action="export-gif">download gif</button>
       <button data-action="share">copy share link</button>
       ${PUBLISH_DISABLED ? "" : `<button data-action="publish">publish to gallery</button>`}
+      <button data-action="make-merch" id="merchBtn" hidden>make merch</button>
       <p id="status">${PUBLISH_DISABLED ? "demo mode — draw, export a gif, or copy a share link" : ""}</p>
     </section>
   </main>
@@ -137,6 +139,22 @@ const paletteEl = document.getElementById("palette")!;
 const statusEl = document.getElementById("status")!;
 const picker = document.getElementById("palettePicker") as HTMLDialogElement;
 const baseGridEl = document.getElementById("baseGrid")!;
+const merchBtnEl = document.getElementById("merchBtn") as HTMLButtonElement | null;
+
+function setLastPublishedId(id: string | null): void {
+  lastPublishedId = id;
+  if (!merchBtnEl) return;
+  merchBtnEl.hidden = id === null;
+}
+
+function openMerch(): void {
+  if (!lastPublishedId) return;
+  const base = (import.meta.env.BASE_URL ?? "/").replace(/\/$/, "/");
+  const frame = state.current;
+  location.assign(
+    `${base}merch?d=${encodeURIComponent(lastPublishedId)}&frame=${frame}`,
+  );
+}
 
 // -- Rendering --------------------------------------------------------------
 
@@ -309,12 +327,13 @@ function deleteCurrentFrame(): void {
   persist();
 }
 
-function resetEditor(): void {
+function resetEditor(opts: { keepPublishedId?: boolean } = {}): void {
   stopPlay();
   state.frames = [new Bitmap()];
   state.current = 0;
   history.clear();
   localId = null;
+  if (!opts.keepPublishedId) setLastPublishedId(null);
   render();
   persist();
 }
@@ -441,9 +460,11 @@ async function handlePublish(): Promise<void> {
         publishedId: result.id,
       });
     }
+    setLastPublishedId(result.id);
     // Start a fresh drawing so the editor doesn't keep the just-published
-    // state around and accidentally re-mint a near-duplicate.
-    resetEditor();
+    // state around and accidentally re-mint a near-duplicate. The merch
+    // button keeps its state — it lets the user buy what they just published.
+    resetEditor({ keepPublishedId: true });
   } catch (err) {
     setStatus(`publish failed: ${err instanceof Error ? err.message : String(err)}`);
   }
@@ -537,6 +558,7 @@ document.querySelectorAll<HTMLButtonElement>("[data-action]").forEach((b) =>
       case "export-gif": stopPlay(); downloadGif(); break;
       case "share": stopPlay(); copyShareLink(); break;
       case "publish": stopPlay(); void handlePublish(); break;
+      case "make-merch": stopPlay(); openMerch(); break;
     }
   }),
 );
@@ -567,6 +589,7 @@ async function boot(): Promise<void> {
       state.frames = decoded.frames;
       if (decoded.activePalette) activePalette = decoded.activePalette;
       state.current = 0;
+      setLastPublishedId(forkId);
     } catch (err) {
       setStatus(`fork failed: ${err instanceof Error ? err.message : String(err)}`);
     }

--- a/src/merch.ts
+++ b/src/merch.ts
@@ -1,0 +1,285 @@
+import { Bitmap } from "./editor/bitmap.js";
+import { PixelCanvas } from "./editor/canvas.js";
+import { decodeGif } from "./editor/gif.js";
+import { activePaletteToRgb, DEFAULT_ACTIVE_PALETTE } from "./editor/palette.js";
+
+interface MerchVariant {
+  id: number;
+  label: string;
+  base_cost_cents: number;
+  retail_cents: number;
+}
+
+interface MerchProduct {
+  id: string;
+  name: string;
+  blueprint_id: number;
+  print_provider_id: number;
+  print_area_px: { width: number; height: number };
+  variants: MerchVariant[];
+}
+
+interface MerchCatalog {
+  products: MerchProduct[];
+}
+
+interface CheckoutResponse {
+  order_id: string;
+  checkout_url: string;
+}
+
+const INGEST_URL = import.meta.env.VITE_INGEST_URL ?? "/ingest";
+const DRAWING_BASE_URL = import.meta.env.VITE_DRAWING_BASE_URL ?? "/drawings";
+const API_BASE = INGEST_URL.replace(/\/ingest\/?$/, "");
+
+const PREVIEW_PIXEL_SIZE = 16;
+const THUMB_PIXEL_SIZE = 4;
+
+const statusEl = document.getElementById("status") as HTMLParagraphElement;
+const productGridEl = document.getElementById("productGrid") as HTMLDivElement;
+const variantPickerEl = document.getElementById("variantPicker") as HTMLDivElement;
+const checkoutBtn = document.getElementById("checkoutBtn") as HTMLButtonElement;
+const previewCanvasEl = document.getElementById("preview") as HTMLCanvasElement;
+const frameStripEl = document.getElementById("frameStrip") as HTMLDivElement;
+
+let frames: Bitmap[] = [];
+let activePalette: Uint8Array = new Uint8Array(DEFAULT_ACTIVE_PALETTE);
+let drawingId: string | null = null;
+let currentFrame = 0;
+let selectedProduct: MerchProduct | null = null;
+let selectedVariant: MerchVariant | null = null;
+let checkoutInFlight = false;
+let previewCanvas: PixelCanvas | null = null;
+
+function setStatus(msg: string): void {
+  statusEl.textContent = msg;
+}
+
+function formatUsd(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function paletteRgb() {
+  return activePaletteToRgb(activePalette);
+}
+
+function renderPreview(): void {
+  if (!previewCanvas) {
+    previewCanvas = new PixelCanvas(previewCanvasEl, {
+      pixelSize: PREVIEW_PIXEL_SIZE,
+      showGrid: false,
+      gridColor: "",
+    });
+  }
+  previewCanvas.draw(frames[currentFrame], paletteRgb());
+}
+
+function renderFrameStrip(): void {
+  if (frames.length <= 1) {
+    frameStripEl.hidden = true;
+    frameStripEl.innerHTML = "";
+    return;
+  }
+  frameStripEl.hidden = false;
+  frameStripEl.innerHTML = "";
+  const palette = paletteRgb();
+  frames.forEach((frame, idx) => {
+    const wrap = document.createElement("button");
+    wrap.type = "button";
+    wrap.className = "frame" + (idx === currentFrame ? " selected" : "");
+    const cv = document.createElement("canvas");
+    const thumb = new PixelCanvas(cv, {
+      pixelSize: THUMB_PIXEL_SIZE,
+      showGrid: false,
+      gridColor: "",
+    });
+    thumb.draw(frame, palette);
+    wrap.appendChild(cv);
+    const label = document.createElement("span");
+    label.textContent = String(idx + 1);
+    wrap.appendChild(label);
+    wrap.addEventListener("click", () => selectFrame(idx));
+    frameStripEl.appendChild(wrap);
+  });
+}
+
+function selectFrame(idx: number): void {
+  if (idx < 0 || idx >= frames.length || idx === currentFrame) return;
+  currentFrame = idx;
+  renderPreview();
+  renderFrameStrip();
+  if (drawingId) {
+    const url = new URL(location.href);
+    url.searchParams.set("d", drawingId);
+    url.searchParams.set("frame", String(currentFrame));
+    history.replaceState(null, "", url.toString());
+  }
+}
+
+function lowestPrice(p: MerchProduct): number {
+  return p.variants.reduce((min, v) => Math.min(min, v.retail_cents), Infinity);
+}
+
+function renderCatalog(catalog: MerchCatalog): void {
+  productGridEl.innerHTML = "";
+  if (catalog.products.length === 0) {
+    productGridEl.innerHTML = "<p class=\"muted\">No products available yet.</p>";
+    return;
+  }
+  for (const product of catalog.products) {
+    const card = document.createElement("button");
+    card.type = "button";
+    card.className = "product-card";
+    card.dataset.productId = product.id;
+    const name = document.createElement("strong");
+    name.textContent = product.name;
+    const price = document.createElement("span");
+    const min = lowestPrice(product);
+    price.textContent = `from ${formatUsd(min)}`;
+    card.append(name, price);
+    card.addEventListener("click", () => selectProduct(product));
+    productGridEl.appendChild(card);
+  }
+}
+
+function selectProduct(product: MerchProduct): void {
+  selectedProduct = product;
+  selectedVariant = null;
+  document.querySelectorAll<HTMLButtonElement>(".product-card").forEach((el) => {
+    el.classList.toggle("selected", el.dataset.productId === product.id);
+  });
+  renderVariantPicker();
+  updateCheckoutButton();
+}
+
+function renderVariantPicker(): void {
+  if (!selectedProduct) {
+    variantPickerEl.hidden = true;
+    variantPickerEl.innerHTML = "";
+    return;
+  }
+  variantPickerEl.hidden = false;
+  variantPickerEl.innerHTML = "";
+  const heading = document.createElement("h3");
+  heading.textContent = `${selectedProduct.name} — pick a variant`;
+  variantPickerEl.appendChild(heading);
+  for (const variant of selectedProduct.variants) {
+    const id = `variant-${variant.id}`;
+    const wrap = document.createElement("label");
+    wrap.className = "variant-option";
+    wrap.htmlFor = id;
+    const radio = document.createElement("input");
+    radio.type = "radio";
+    radio.name = "variant";
+    radio.id = id;
+    radio.value = String(variant.id);
+    radio.addEventListener("change", () => {
+      selectedVariant = variant;
+      updateCheckoutButton();
+    });
+    const label = document.createElement("span");
+    label.textContent = `${variant.label} — ${formatUsd(variant.retail_cents)}`;
+    wrap.append(radio, label);
+    variantPickerEl.appendChild(wrap);
+  }
+}
+
+function updateCheckoutButton(): void {
+  const ready = !!(drawingId && selectedProduct && selectedVariant && !checkoutInFlight);
+  checkoutBtn.disabled = !ready;
+  checkoutBtn.textContent = checkoutInFlight ? "redirecting…" : "continue to checkout";
+}
+
+async function fetchCatalog(): Promise<MerchCatalog> {
+  const res = await fetch(`${API_BASE}/merch/products`, { cache: "no-store" });
+  if (!res.ok) throw new Error(`catalog fetch failed: ${res.status}`);
+  return (await res.json()) as MerchCatalog;
+}
+
+async function fetchDrawing(id: string): Promise<Uint8Array> {
+  const res = await fetch(`${DRAWING_BASE_URL}/${id}.gif`);
+  if (!res.ok) throw new Error(`drawing fetch failed: ${res.status}`);
+  const buf = await res.arrayBuffer();
+  return new Uint8Array(buf);
+}
+
+async function handleCheckout(): Promise<void> {
+  if (!drawingId || !selectedProduct || !selectedVariant || checkoutInFlight) return;
+  checkoutInFlight = true;
+  updateCheckoutButton();
+  setStatus("creating checkout session…");
+  try {
+    // {ORDER_ID} is substituted server-side before redirect to Stripe.
+    const successUrl = `${location.origin}/merch/order/{ORDER_ID}`;
+    const cancelUrl = `${location.origin}/merch?d=${encodeURIComponent(drawingId)}&frame=${currentFrame}`;
+    const res = await fetch(`${API_BASE}/merch/checkout`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        drawing_id: drawingId,
+        frame: currentFrame,
+        product_id: selectedProduct.id,
+        variant_id: selectedVariant.id,
+        success_url: successUrl,
+        cancel_url: cancelUrl,
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`${res.status} ${(await res.text()) || res.statusText}`);
+    }
+    const body = (await res.json()) as CheckoutResponse;
+    if (!body.checkout_url) throw new Error("server returned no checkout_url");
+    location.href = body.checkout_url;
+  } catch (err) {
+    checkoutInFlight = false;
+    updateCheckoutButton();
+    setStatus(`checkout failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+async function boot(): Promise<void> {
+  const params = new URL(location.href).searchParams;
+  const id = params.get("d");
+  const frameParam = params.get("frame");
+  if (!id || !/^[0-9a-f]{64}$/.test(id)) {
+    setStatus("missing or malformed drawing id (?d=<64 hex>).");
+    return;
+  }
+  drawingId = id;
+
+  setStatus("loading drawing…");
+  try {
+    const bytes = await fetchDrawing(id);
+    const decoded = decodeGif(bytes);
+    frames = decoded.frames;
+    if (decoded.activePalette) activePalette = decoded.activePalette;
+  } catch (err) {
+    setStatus(`failed to load drawing: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+
+  const requested = frameParam ? Number.parseInt(frameParam, 10) : 0;
+  if (!Number.isInteger(requested) || requested < 0 || requested >= frames.length) {
+    setStatus(`frame ${frameParam} is out of range (0–${frames.length - 1}).`);
+    return;
+  }
+  currentFrame = requested;
+
+  renderPreview();
+  renderFrameStrip();
+
+  setStatus("loading catalog…");
+  try {
+    const catalog = await fetchCatalog();
+    renderCatalog(catalog);
+    setStatus("");
+  } catch (err) {
+    setStatus(`failed to load catalog: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  checkoutBtn.addEventListener("click", () => {
+    void handleCheckout();
+  });
+}
+
+void boot();

--- a/src/order.ts
+++ b/src/order.ts
@@ -1,0 +1,148 @@
+interface OrderView {
+  order_id?: string;
+  drawing_id?: string;
+  frame?: number;
+  product_id?: string;
+  variant_id?: number;
+  retail_cents?: number;
+  status?: string;
+  created_at?: string;
+  updated_at?: string;
+  customer_email?: string;
+}
+
+const INGEST_URL = import.meta.env.VITE_INGEST_URL ?? "/ingest";
+const DRAWING_BASE_URL = import.meta.env.VITE_DRAWING_BASE_URL ?? "/drawings";
+const API_BASE = INGEST_URL.replace(/\/ingest\/?$/, "");
+
+const ORDER_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const POLL_MS = 30_000;
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  "shipped",
+  "delivered",
+  "failed",
+  "refunded",
+]);
+
+const STATUS_COPY: Record<string, string> = {
+  pending: "Waiting for payment confirmation. Refresh in a minute.",
+  paid: "Payment received! Sending to Printify…",
+  submitted: "In production.",
+  in_production: "In production.",
+  shipped: "Shipped! Check your email for tracking.",
+  delivered: "Delivered.",
+  failed: "Something went wrong. We'll refund you shortly.",
+  refunded: "Refunded.",
+};
+
+const cardEl = document.getElementById("orderCard") as HTMLDivElement;
+let pollTimer: ReturnType<typeof setTimeout> | null = null;
+
+function parseOrderId(): string | null {
+  const m = location.pathname.match(/\/merch\/order\/([0-9a-f-]+)\/?$/);
+  if (!m) return null;
+  return ORDER_ID_RE.test(m[1]) ? m[1] : null;
+}
+
+function formatUsd(cents: number | undefined): string {
+  if (typeof cents !== "number") return "";
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (ch) => {
+    switch (ch) {
+      case "&": return "&amp;";
+      case "<": return "&lt;";
+      case ">": return "&gt;";
+      case "\"": return "&quot;";
+      default: return "&#39;";
+    }
+  });
+}
+
+function renderError(msg: string): void {
+  cardEl.innerHTML = `<p class="merch-status">${escapeHtml(msg)}</p>`;
+}
+
+function renderRetry(msg: string, onRetry: () => void): void {
+  cardEl.innerHTML = `
+    <p class="merch-status">${escapeHtml(msg)}</p>
+    <button id="retryBtn" type="button">retry</button>
+  `;
+  document.getElementById("retryBtn")?.addEventListener("click", onRetry);
+}
+
+function renderOrder(order: OrderView): void {
+  const status = order.status ?? "unknown";
+  const copy = STATUS_COPY[status] ?? `Status: ${status}.`;
+  const drawingImg = order.drawing_id
+    ? `<img class="order-thumb" src="${DRAWING_BASE_URL}/${escapeHtml(order.drawing_id)}.gif" alt="drawing ${escapeHtml(order.drawing_id.slice(0, 8))}" width="128" height="128" />`
+    : "";
+  const lines: string[] = [];
+  if (order.order_id) lines.push(`<dt>order</dt><dd><code>${escapeHtml(order.order_id)}</code></dd>`);
+  if (order.product_id) {
+    const variant = order.variant_id !== undefined ? ` · variant ${escapeHtml(String(order.variant_id))}` : "";
+    lines.push(`<dt>product</dt><dd>${escapeHtml(order.product_id)}${variant}</dd>`);
+  }
+  if (order.retail_cents !== undefined) {
+    lines.push(`<dt>amount</dt><dd>${escapeHtml(formatUsd(order.retail_cents))}</dd>`);
+  }
+  if (order.frame !== undefined) lines.push(`<dt>frame</dt><dd>${escapeHtml(String(order.frame + 1))}</dd>`);
+  if (order.created_at) lines.push(`<dt>placed</dt><dd>${escapeHtml(order.created_at)}</dd>`);
+
+  cardEl.innerHTML = `
+    ${drawingImg}
+    <p class="status-badge status-${escapeHtml(status)}">${escapeHtml(status)}</p>
+    <p class="merch-status">${escapeHtml(copy)}</p>
+    <dl>${lines.join("")}</dl>
+  `;
+}
+
+async function fetchOrder(id: string): Promise<OrderView | null> {
+  const res = await fetch(`${API_BASE}/merch/order/${encodeURIComponent(id)}`, {
+    cache: "no-store",
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return (await res.json()) as OrderView;
+}
+
+async function load(id: string): Promise<void> {
+  let order: OrderView | null;
+  try {
+    order = await fetchOrder(id);
+  } catch (err) {
+    renderRetry(
+      `failed to load order: ${err instanceof Error ? err.message : String(err)}`,
+      () => void load(id),
+    );
+    return;
+  }
+  if (!order) {
+    renderError("Order not found.");
+    return;
+  }
+  renderOrder(order);
+  schedulePoll(id, order.status ?? "");
+}
+
+function schedulePoll(id: string, status: string): void {
+  if (pollTimer !== null) {
+    clearTimeout(pollTimer);
+    pollTimer = null;
+  }
+  if (TERMINAL_STATUSES.has(status)) return;
+  pollTimer = setTimeout(() => void load(id), POLL_MS);
+}
+
+function boot(): void {
+  const id = parseOrderId();
+  if (!id) {
+    renderError("Order id missing or malformed in URL.");
+    return;
+  }
+  void load(id);
+}
+
+boot();

--- a/src/style.css
+++ b/src/style.css
@@ -225,3 +225,116 @@ footer {
   text-align: center;
 }
 footer a { color: inherit; }
+
+/* -- Merch picker + order status pages ----------------------------------- */
+.merch-body main { padding-top: 0.5rem; }
+.merch-page {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+.merch-preview { display: flex; flex-direction: column; gap: 0.75rem; }
+#preview {
+  image-rendering: pixelated;
+  width: 256px;
+  height: 256px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+}
+.frame-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+.frame-strip .frame { padding: 0.2rem; background: var(--panel); }
+.frame-strip .frame canvas {
+  width: 64px;
+  height: 64px;
+  image-rendering: pixelated;
+}
+
+.merch-catalog h2 { font-size: 1rem; letter-spacing: 0.1em; margin: 0 0 0.75rem; }
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+.product-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  padding: 0.6rem;
+  text-align: left;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  cursor: pointer;
+}
+.product-card.selected { border-color: var(--accent); color: var(--accent); }
+.product-card span { font-size: 0.8rem; color: #aaa; }
+.product-card.selected span { color: var(--accent); }
+
+.variant-picker {
+  border: 1px solid var(--border);
+  background: var(--panel);
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+}
+.variant-picker h3 { margin: 0 0 0.5rem; font-size: 0.9rem; }
+.variant-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  cursor: pointer;
+}
+
+.merch-status { font-size: 0.85rem; color: #aaa; min-height: 1.2em; word-break: break-word; }
+.muted { color: #888; font-size: 0.85rem; }
+
+#checkoutBtn { width: 100%; padding: 0.6rem; }
+#checkoutBtn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.order-page { max-width: 480px; margin: 0 auto; }
+.order-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+.order-thumb {
+  image-rendering: pixelated;
+  width: 128px;
+  height: 128px;
+  border: 1px solid var(--border);
+}
+.status-badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid var(--border);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.75rem;
+}
+.status-paid, .status-submitted, .status-in_production { color: var(--accent); border-color: var(--accent); }
+.status-shipped, .status-delivered { color: #6fdc6f; border-color: #6fdc6f; }
+.status-failed, .status-refunded { color: #ff6f6f; border-color: #ff6f6f; }
+.order-card dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.25rem 0.75rem;
+  margin: 0;
+  font-size: 0.85rem;
+}
+.order-card dt { color: #888; }
+.order-card dd { margin: 0; word-break: break-all; }
+
+@media (max-width: 720px) {
+  .merch-page { grid-template-columns: 1fr; }
+  #preview { width: 100%; height: auto; aspect-ratio: 1 / 1; }
+}

--- a/test/merch-lambda.test.ts
+++ b/test/merch-lambda.test.ts
@@ -297,6 +297,29 @@ test("POST /merch/checkout: happy path persists, calls Stripe, transitions, retu
   assert.deepEqual(t.patch, { stripe_session_id: "cs_test_happy" });
 });
 
+test("POST /merch/checkout: substitutes {ORDER_ID} in success_url", async () => {
+  const { deps, stripeCalls } = buildDeps();
+  const res = await handle(
+    event("POST /merch/checkout", {
+      body: {
+        drawing_id: "a".repeat(64),
+        frame: 0,
+        product_id: "tee",
+        variant_id: 18395,
+        success_url: "https://drawbang.example/merch/order/{ORDER_ID}",
+        cancel_url: "https://drawbang.example/merch?d=" + "a".repeat(64),
+      },
+    }),
+    deps,
+  );
+  assert.equal(statusOf(res), 200);
+  assert.equal(stripeCalls.createCheckoutSession.length, 1);
+  assert.equal(
+    stripeCalls.createCheckoutSession[0].successUrl,
+    "https://drawbang.example/merch/order/ord_test_1",
+  );
+});
+
 test("POST /merch/webhook/stripe: 400 when signature header is missing", async () => {
   const { deps, stripeCalls } = buildDeps();
   const res = await handle(event("POST /merch/webhook/stripe", { body: { type: "evt" } }), deps);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
       input: {
         main: resolve(__dirname, "index.html"),
         "pow-test": resolve(__dirname, "pow-test.html"),
+        merch: resolve(__dirname, "merch.html"),
+        order: resolve(__dirname, "order.html"),
       },
     },
   },


### PR DESCRIPTION
Connects the existing merch backend to a clickable purchase flow:
- "make merch" entry points on the editor (visible after publish/fork)
  and on every published drawing page.
- /merch picker page: preview canvas, frame picker for multi-frame
  drawings, product/variant catalog, "continue to checkout" button
  that POSTs to /merch/checkout and redirects to Stripe.
- /merch/order/<uuid> status page polls the order every 30s until a
  terminal state.
- Server-side {ORDER_ID} substitution in success_url so the picker
  can template it without knowing the id.
- CloudFront rewrites for the two new clean URLs.