### PR TITLE
merch: render print asset as SVG instead of upscaled PNG (#120)

### DIFF
--- a/merch/dispatch.ts
+++ b/merch/dispatch.ts
@@ -2,7 +2,7 @@ import { decodeGif } from "../src/editor/gif.js";
 import type { OrdersStore, Order } from "./orders.js";
 import { PrintifyError, type PrintifyClient } from "./printify.js";
 import type { MerchCatalog } from "./lambda.js";
-import { upscaleBitmapToPng } from "./upscale.js";
+import { upscaleBitmapToSvg } from "./upscale.js";
 
 export interface PlacePrintifyOrderDeps {
   orders: OrdersStore;
@@ -56,24 +56,21 @@ export async function placePrintifyOrder(
       const frame = decoded.frames[order.frame];
       if (!frame) throw new Error(`frame index out of range: ${order.frame}`);
 
-      // Upscale target: largest print-area dim, but capped so we don't
-      // produce a multi-thousand-pixel PNG just to ship 16×16 of source. The
-      // tee blueprint at ~5000px would otherwise OOM the Lambda during PNG
-      // encode + base64 upload. Printify rescales the image to fill the
-      // print area regardless, so anything ≥ 16×64 = 1024 keeps the pixel-
-      // art look without wasting memory. Round down to a multiple of 16 so
-      // each source pixel still becomes an integer-sized block.
-      const MAX_UPSCALE_PX = 1600;
-      const maxDim = Math.min(
-        MAX_UPSCALE_PX,
-        Math.max(product.print_area_px.width, product.print_area_px.height),
-      );
-      const sizePx = Math.floor(maxDim / 16) * 16;
-      const pngBytes = await upscaleBitmapToPng(frame, decoded.activePalette, { sizePx });
+      // Render the print asset as an SVG sized to the largest print-area
+      // dim, rounded down to a multiple of 16 so each source pixel maps
+      // to an integer-sized rect. SVG output is O(rects) in memory (≤256
+      // rects total) regardless of sizePx, so the pre-cap from the PNG
+      // pipeline is gone — Printify gets a vector asset it can rasterise
+      // at print resolution itself.
+      const sizePx =
+        Math.floor(
+          Math.max(product.print_area_px.width, product.print_area_px.height) / 16,
+        ) * 16;
+      const svgBytes = upscaleBitmapToSvg(frame, decoded.activePalette, { sizePx });
 
       const image = await deps.printify.uploadImage(
-        `drawbang-${order.drawing_id}-f${order.frame}.png`,
-        pngBytes,
+        `drawbang-${order.drawing_id}-f${order.frame}.svg`,
+        svgBytes,
       );
 
       const drawingUrl = `${deps.publicBaseUrl}/d/${order.drawing_id}`;

--- a/merch/upscale.ts
+++ b/merch/upscale.ts
@@ -1,4 +1,3 @@
-import { PNG } from "pngjs";
 import { Bitmap, TRANSPARENT } from "../src/editor/bitmap.js";
 import { activePaletteToRgb } from "../src/editor/palette.js";
 
@@ -7,11 +6,20 @@ export interface UpscaleOptions {
   background?: [number, number, number] | null;
 }
 
-export async function upscaleBitmapToPng(
+// Emit a 16×16 pixel-art bitmap as an SVG sized to `sizePx × sizePx`. Each
+// non-transparent source pixel becomes one `<rect width="1" height="1">`
+// inside a `0 0 16 16` viewBox; `shape-rendering="crispEdges"` keeps the
+// pixel-art look at any rasterization scale Printify ends up choosing.
+//
+// Compared to the old PNG path this scales to print-area sizes (≥4000 px
+// per side) without allocating a full-resolution RGBA buffer — the output
+// is bounded by 16×16 = 256 rects regardless of `sizePx`. Memory usage is
+// O(rects), not O(pixels).
+export function upscaleBitmapToSvg(
   bitmap: Bitmap,
   activePalette: Uint8Array,
   opts: UpscaleOptions,
-): Promise<Uint8Array> {
+): Uint8Array {
   const { sizePx } = opts;
   const background = opts.background ?? null;
 
@@ -25,54 +33,31 @@ export async function upscaleBitmapToPng(
   }
 
   const colors = activePaletteToRgb(activePalette);
-  const blockX = sizePx / bitmap.width;
-  const blockY = sizePx / bitmap.height;
-  const png = new PNG({ width: sizePx, height: sizePx });
-  const data = png.data;
-
-  for (let sy = 0; sy < bitmap.height; sy++) {
-    for (let sx = 0; sx < bitmap.width; sx++) {
-      const idx = bitmap.get(sx, sy);
-      let r: number, g: number, b: number, a: number;
-      if (idx === TRANSPARENT) {
-        if (background === null) {
-          r = 0; g = 0; b = 0; a = 0;
-        } else {
-          [r, g, b] = background;
-          a = 255;
-        }
-      } else {
-        [r, g, b] = colors[idx];
-        a = 255;
-      }
-      const x0 = sx * blockX;
-      const y0 = sy * blockY;
-      for (let py = 0; py < blockY; py++) {
-        let off = ((y0 + py) * sizePx + x0) * 4;
-        for (let px = 0; px < blockX; px++) {
-          data[off++] = r;
-          data[off++] = g;
-          data[off++] = b;
-          data[off++] = a;
-        }
-      }
+  const W = bitmap.width;
+  const H = bitmap.height;
+  const parts: string[] = [];
+  parts.push(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${sizePx}" height="${sizePx}" viewBox="0 0 ${W} ${H}" shape-rendering="crispEdges">`,
+  );
+  if (background !== null) {
+    parts.push(`<rect width="${W}" height="${H}" fill="${rgbHex(background)}"/>`);
+  }
+  for (let y = 0; y < H; y++) {
+    for (let x = 0; x < W; x++) {
+      const idx = bitmap.get(x, y);
+      if (idx === TRANSPARENT) continue;
+      const fill = rgbHex(colors[idx]);
+      parts.push(`<rect x="${x}" y="${y}" width="1" height="1" fill="${fill}"/>`);
     }
   }
+  parts.push(`</svg>`);
+  return new TextEncoder().encode(parts.join(""));
+}
 
-  return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    png.pack()
-      .on("data", (chunk: Buffer) => chunks.push(chunk))
-      .on("end", () => {
-        const total = chunks.reduce((n, c) => n + c.length, 0);
-        const out = new Uint8Array(total);
-        let p = 0;
-        for (const c of chunks) {
-          out.set(c, p);
-          p += c.length;
-        }
-        resolve(out);
-      })
-      .on("error", reject);
-  });
+function rgbHex([r, g, b]: readonly [number, number, number]): string {
+  return `#${hex(r)}${hex(g)}${hex(b)}`;
+}
+
+function hex(n: number): string {
+  return n.toString(16).padStart(2, "0");
 }

--- a/test/dispatch.test.ts
+++ b/test/dispatch.test.ts
@@ -161,7 +161,7 @@ test("happy path: upload -> create product -> create order -> submitted", async 
   const upload = printifyCalls.uploadImage[0];
   assert.equal(
     upload.filename,
-    `drawbang-${"f".repeat(64)}-f0.png`,
+    `drawbang-${"f".repeat(64)}-f0.svg`,
   );
   assert.ok(upload.bytesLen > 0, "non-empty PNG");
 
@@ -278,11 +278,11 @@ test("placeholder_positions: each configured position uploads the same image", a
   }
 });
 
-test("upscale caps the PNG size so a giant print area doesn't OOM the lambda", async () => {
-  // tee print area is 4500×5400, but the cap kicks in long before that. The
-  // resulting PNG should be small enough to fit in normal Lambda memory:
-  // a 16×16 source upscaled to ≤1600×1600 of mostly-zero pixels compresses
-  // to well under 100KB.
+test("upscale to a giant print area still uploads a tiny SVG", async () => {
+  // tee print area is 4500×5400. The pre-SVG PNG path needed a hard cap
+  // here to avoid an 80MB raster buffer in Lambda memory; the SVG path
+  // is bounded by rect count, not sizePx, so the upload payload stays
+  // well under any sensible budget regardless of print resolution.
   const catalogOdd: MerchCatalog = {
     products: [
       {
@@ -300,12 +300,11 @@ test("upscale caps the PNG size so a giant print area doesn't OOM the lambda", a
   deps.catalog = catalogOdd;
   await placePrintifyOrder("ord_42", deps);
   assert.equal(printifyCalls.uploadImage.length, 1);
+  assert.ok(printifyCalls.uploadImage[0].filename.endsWith(".svg"));
   assert.ok(printifyCalls.uploadImage[0].bytesLen > 0);
-  // 4912×4912 RGBA PNG would be hundreds of KB even after compression.
-  // The cap (≤1600px) keeps it well under that.
   assert.ok(
-    printifyCalls.uploadImage[0].bytesLen < 200_000,
-    `PNG bytes ${printifyCalls.uploadImage[0].bytesLen} exceeds the cap budget`,
+    printifyCalls.uploadImage[0].bytesLen < 32_000,
+    `SVG bytes ${printifyCalls.uploadImage[0].bytesLen} unexpectedly large for a 16×16 source`,
   );
 });
 

--- a/test/upscale.test.ts
+++ b/test/upscale.test.ts
@@ -1,82 +1,88 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
-import { PNG } from "pngjs";
 import { Bitmap, TRANSPARENT } from "../src/editor/bitmap.js";
 import { DEFAULT_ACTIVE_PALETTE, activePaletteToRgb } from "../src/editor/palette.js";
-import { upscaleBitmapToPng } from "../merch/upscale.js";
+import { upscaleBitmapToSvg } from "../merch/upscale.js";
 
-function decodePng(bytes: Uint8Array): PNG {
-  return PNG.sync.read(Buffer.from(bytes));
+function decode(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
 }
 
-function readPixel(png: PNG, x: number, y: number): [number, number, number, number] {
-  const i = (y * png.width + x) * 4;
-  return [png.data[i], png.data[i + 1], png.data[i + 2], png.data[i + 3]];
+function rgbHex([r, g, b]: readonly [number, number, number]): string {
+  const h = (n: number) => n.toString(16).padStart(2, "0");
+  return `#${h(r)}${h(g)}${h(b)}`;
 }
 
-test("upscale: produces a square RGBA PNG of the requested size", async () => {
+test("upscale: emits an SVG sized to the requested px and a 16×16 viewBox", () => {
   const b = new Bitmap();
-  const bytes = await upscaleBitmapToPng(b, DEFAULT_ACTIVE_PALETTE, { sizePx: 32 });
-  const png = decodePng(bytes);
-  assert.equal(png.width, 32);
-  assert.equal(png.height, 32);
+  const svg = decode(upscaleBitmapToSvg(b, DEFAULT_ACTIVE_PALETTE, { sizePx: 32 }));
+  assert.match(svg, /^<svg /);
+  assert.match(svg, /<\/svg>$/);
+  assert.match(svg, /\bwidth="32"/);
+  assert.match(svg, /\bheight="32"/);
+  assert.match(svg, /\bviewBox="0 0 16 16"/);
+  assert.match(svg, /\bshape-rendering="crispEdges"/);
 });
 
-test("upscale: each source pixel becomes a uniform N×N block of the palette color", async () => {
+test("upscale: emits a fill rect per non-transparent source pixel", () => {
   const b = new Bitmap();
-  // Slot 5 -> a known RGB via the active palette
   b.set(2, 3, 5);
-  const sizePx = 64; // block = 4
-  const bytes = await upscaleBitmapToPng(b, DEFAULT_ACTIVE_PALETTE, { sizePx });
-  const png = decodePng(bytes);
+  b.set(7, 7, 9);
+  const svg = decode(upscaleBitmapToSvg(b, DEFAULT_ACTIVE_PALETTE, { sizePx: 1600 }));
   const colors = activePaletteToRgb(DEFAULT_ACTIVE_PALETTE);
-  const [r, g, b5] = colors[5];
-  const block = sizePx / 16;
-  // Sample every pixel inside the (2,3) block; all must equal slot 5 RGBA
-  for (let py = 0; py < block; py++) {
-    for (let px = 0; px < block; px++) {
-      const x = 2 * block + px;
-      const y = 3 * block + py;
-      assert.deepEqual(readPixel(png, x, y), [r, g, b5, 255], `pixel at (${x},${y})`);
-    }
-  }
-  // A neighboring block (1,3) should be transparent (default bg)
-  assert.deepEqual(readPixel(png, 1 * block, 3 * block), [0, 0, 0, 0]);
+  // Two filled cells -> exactly two <rect ... fill=...> entries (background
+  // null => no full-canvas backdrop).
+  const rects = svg.match(/<rect[^/]*\/>/g) ?? [];
+  assert.equal(rects.length, 2);
+  assert.ok(svg.includes(`<rect x="2" y="3" width="1" height="1" fill="${rgbHex(colors[5])}"/>`));
+  assert.ok(svg.includes(`<rect x="7" y="7" width="1" height="1" fill="${rgbHex(colors[9])}"/>`));
 });
 
-test("upscale: transparent pixels stay transparent when background is null", async () => {
+test("upscale: skips transparent pixels when background is null", () => {
   const b = new Bitmap();
-  // All transparent by default; explicitly set one for clarity
   b.set(0, 0, TRANSPARENT);
-  const bytes = await upscaleBitmapToPng(b, DEFAULT_ACTIVE_PALETTE, { sizePx: 32 });
-  const png = decodePng(bytes);
-  assert.deepEqual(readPixel(png, 0, 0), [0, 0, 0, 0]);
-  assert.deepEqual(readPixel(png, 31, 31), [0, 0, 0, 0]);
+  const svg = decode(upscaleBitmapToSvg(b, DEFAULT_ACTIVE_PALETTE, { sizePx: 32 }));
+  // No <rect> at all — fully transparent bitmap with no backdrop.
+  assert.equal(svg.match(/<rect/g), null);
 });
 
-test("upscale: transparent pixels take the background RGB at full alpha when provided", async () => {
+test("upscale: emits a single full-canvas backdrop rect when background is set", () => {
   const b = new Bitmap();
-  const bytes = await upscaleBitmapToPng(b, DEFAULT_ACTIVE_PALETTE, {
-    sizePx: 32,
-    background: [12, 34, 56],
-  });
-  const png = decodePng(bytes);
-  assert.deepEqual(readPixel(png, 0, 0), [12, 34, 56, 255]);
-  assert.deepEqual(readPixel(png, 31, 31), [12, 34, 56, 255]);
+  const svg = decode(
+    upscaleBitmapToSvg(b, DEFAULT_ACTIVE_PALETTE, { sizePx: 32, background: [12, 34, 56] }),
+  );
+  const rects = svg.match(/<rect[^/]*\/>/g) ?? [];
+  assert.equal(rects.length, 1);
+  assert.ok(svg.includes(`<rect width="16" height="16" fill="#0c2238"/>`));
 });
 
-test("upscale: rejects sizePx that is not a multiple of 16", async () => {
+test("upscale: rejects sizePx that is not a multiple of 16", () => {
   const b = new Bitmap();
-  await assert.rejects(
-    () => upscaleBitmapToPng(b, DEFAULT_ACTIVE_PALETTE, { sizePx: 33 }),
+  assert.throws(
+    () => upscaleBitmapToSvg(b, DEFAULT_ACTIVE_PALETTE, { sizePx: 33 }),
     /multiple of bitmap dims/,
   );
 });
 
-test("upscale: rejects non-positive sizePx", async () => {
+test("upscale: rejects non-positive sizePx", () => {
   const b = new Bitmap();
-  await assert.rejects(
-    () => upscaleBitmapToPng(b, DEFAULT_ACTIVE_PALETTE, { sizePx: 0 }),
+  assert.throws(
+    () => upscaleBitmapToSvg(b, DEFAULT_ACTIVE_PALETTE, { sizePx: 0 }),
     /positive integer/,
+  );
+});
+
+test("upscale: SVG size is bounded by rect count, not sizePx (memory regression test)", () => {
+  // The whole point of the SVG path: a 4000px output for an all-filled
+  // 16×16 source should still produce a tiny payload, because the SVG is
+  // 256 rects regardless of sizePx.
+  const b = new Bitmap();
+  for (let y = 0; y < 16; y++) for (let x = 0; x < 16; x++) b.set(x, y, (x + y) & 7);
+  const bytes = upscaleBitmapToSvg(b, DEFAULT_ACTIVE_PALETTE, { sizePx: 4000 });
+  // ~70 chars per rect × 256 rects ≈ 18KB. Bound generously at 32KB to leave
+  // headroom for hex-color or attribute formatting tweaks.
+  assert.ok(
+    bytes.byteLength < 32_000,
+    `SVG bytes ${bytes.byteLength} unexpectedly large at sizePx=4000`,
   );
 });


### PR DESCRIPTION
Closes #120.

## Summary
- Replace the upscaled-PNG print asset with an SVG (`viewBox="0 0 16 16"`, one `<rect width="1" height="1">` per non-transparent source pixel, `shape-rendering="crispEdges"`).
- Memory is now O(rects) — bounded by 256 regardless of `sizePx` — instead of O(width × height) (~65 MB raw buffer at the tee's ~4000 px print resolution).
- Drop the `MAX_UPSCALE_PX = 1600` cap in `merch/dispatch.ts`; `sizePx` is now `Math.max(print_area_w, print_area_h)` rounded down to a multiple of 16. Printify rasterises the SVG at print resolution itself.
- Upload filename changes from `drawbang-<id>-f<n>.png` → `.svg`.

## Numbers
| sizePx | old PNG raw buffer | new SVG payload |
|---|---|---|
| 1600 | ~10 MB | ~7 KB |
| 4016 (tee print-area max) | ~65 MB (capped, never reached) | ~7 KB |

(Real run: a 16×16 smiley at `sizePx=4016` is 7,454 bytes on the wire.)

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (relevant suites: 70/70 — gif, pow, share, builder, mockup-config, upscale, dispatch, merch-lambda, merch-webhook)
- [x] `npm run lambda:build` (bundle still builds clean)
- [x] `test/upscale.test.ts` rewritten to assert SVG structure, rect count, transparent-pixel handling, and a memory-regression bound (< 32 KB at `sizePx=4000`)
- [x] `test/dispatch.test.ts` cap-budget test rewritten — now asserts the upload payload stays small and `.svg`-named when run against the full 4500×5400 tee print area
- [ ] End-to-end: place a paid order through the merch lambda and confirm Printify accepts the SVG upload and rasterises correctly (requires live Printify creds — best done as part of the next deploy / smoke run)

https://claude.ai/code/session_01WeatxLKpew9vA8VBdcZm5C

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeatxLKpew9vA8VBdcZm5C)_