### PR TITLE
merch: retry sendToProduction on Printify 400+code 8502

### DIFF
--- a/merch/printify.ts
+++ b/merch/printify.ts
@@ -62,6 +62,15 @@ export class PrintifyError extends Error {
 const DEFAULT_BASE_URL = "https://api.printify.com/v1";
 const RETRY_DELAYS_MS = [500, 1000, 2000, 4000];
 const RETRY_STATUSES = new Set([429, 500, 502, 503, 504]);
+// Slow retry policy: kicks in when Printify returns HTTP 400 with code
+// 8502 ("Operation failed"), which we hit on `sendToProduction` shortly
+// after `createProduct` while the print provider is still rasterising
+// print files from a freshly-uploaded SVG. The race is transient — the
+// same call succeeds within a minute or two — but the existing fast-retry
+// budget (≤7.5s) isn't long enough to ride it out. Total wait here is
+// ~35s, sized to fit comfortably inside the merch lambda's 60s timeout.
+const SLOW_RETRY_DELAYS_MS = [5000, 10000, 20000];
+const PRINTIFY_RETRYABLE_400_CODES = new Set([8502]);
 
 export class PrintifyClient {
   private readonly token: string;
@@ -144,32 +153,47 @@ export class PrintifyClient {
       ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
     };
 
-    for (let attempt = 0; ; attempt++) {
+    let fastAttempt = 0;
+    let slowAttempt = 0;
+    for (;;) {
       const res = await this.fetchImpl(url, init);
       if (res.ok) {
         return (await res.json()) as T;
       }
 
-      const shouldRetry = RETRY_STATUSES.has(res.status) && attempt < RETRY_DELAYS_MS.length;
-      if (!shouldRetry) {
-        let parsed: unknown;
-        try {
-          parsed = await res.json();
-        } catch {
-          parsed = await res.text().catch(() => undefined);
-        }
-        throw new PrintifyError(res.status, parsed);
+      const text = await res.text();
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        parsed = text || undefined;
       }
 
-      let delay = RETRY_DELAYS_MS[attempt];
-      if (res.status === 429) {
-        const ra = res.headers.get("Retry-After");
-        if (ra) {
-          const secs = Number(ra);
-          if (Number.isFinite(secs) && secs >= 0) delay = secs * 1000;
+      if (RETRY_STATUSES.has(res.status) && fastAttempt < RETRY_DELAYS_MS.length) {
+        let delay = RETRY_DELAYS_MS[fastAttempt++];
+        if (res.status === 429) {
+          const ra = res.headers.get("Retry-After");
+          if (ra) {
+            const secs = Number(ra);
+            if (Number.isFinite(secs) && secs >= 0) delay = secs * 1000;
+          }
         }
+        await this.sleepImpl(delay);
+        continue;
       }
-      await this.sleepImpl(delay);
+
+      if (
+        res.status === 400 &&
+        PRINTIFY_RETRYABLE_400_CODES.has(
+          (parsed as { code?: number } | undefined)?.code ?? -1,
+        ) &&
+        slowAttempt < SLOW_RETRY_DELAYS_MS.length
+      ) {
+        await this.sleepImpl(SLOW_RETRY_DELAYS_MS[slowAttempt++]);
+        continue;
+      }
+
+      throw new PrintifyError(res.status, parsed);
     }
   }
 }

--- a/test/printify.test.ts
+++ b/test/printify.test.ts
@@ -181,7 +181,7 @@ test("retries 5xx on the default backoff schedule then succeeds", async () => {
   assert.deepEqual(sleptMs, [500, 1000]);
 });
 
-test("4xx (non-429) throws PrintifyError immediately, no retries", async () => {
+test("4xx (non-429, non-retryable code) throws PrintifyError immediately, no retries", async () => {
   const calls: RecordedCall[] = [];
   const sleptMs: number[] = [];
   const client = new PrintifyClient({
@@ -202,6 +202,73 @@ test("4xx (non-429) throws PrintifyError immediately, no retries", async () => {
   );
   assert.equal(calls.length, 1);
   assert.deepEqual(sleptMs, []);
+});
+
+test("retries HTTP 400 + Printify code 8502 on the slow backoff schedule then succeeds", async () => {
+  // 8502 is a transient image-processing race on sendToProduction. The
+  // fast retry budget (≤7.5s) isn't long enough; the slow schedule
+  // (5s/10s/20s) is what unblocks it.
+  const calls: RecordedCall[] = [];
+  const sleptMs: number[] = [];
+  const client = new PrintifyClient({
+    token: "tok",
+    shopId: "shop_42",
+    fetchImpl: makeFetch(calls, [
+      { status: 400, body: { status: "error", code: 8502, message: "Operation failed." } },
+      { status: 400, body: { status: "error", code: 8502, message: "Operation failed." } },
+      { status: 200, body: { id: "po_1" } },
+    ]),
+    sleepImpl: async (ms) => { sleptMs.push(ms); },
+  });
+
+  const out = await client.sendToProduction("po_1");
+  assert.deepEqual(out, { id: "po_1" });
+  assert.equal(calls.length, 3);
+  assert.deepEqual(sleptMs, [5000, 10000]);
+});
+
+test("HTTP 400 with code != 8502 does not slow-retry", async () => {
+  // Make sure we don't accidentally retry every 400. Only the explicitly
+  // allow-listed codes get the slow backoff.
+  const calls: RecordedCall[] = [];
+  const client = new PrintifyClient({
+    token: "tok",
+    shopId: "shop_42",
+    fetchImpl: makeFetch(calls, [
+      { status: 400, body: { status: "error", code: 9999, message: "Something else." } },
+    ]),
+    sleepImpl: noSleep,
+  });
+
+  await assert.rejects(
+    () => client.sendToProduction("po_1"),
+    (err: unknown) => err instanceof PrintifyError && err.status === 400,
+  );
+  assert.equal(calls.length, 1);
+});
+
+test("8502 retries are exhausted -> PrintifyError surfaces", async () => {
+  const calls: RecordedCall[] = [];
+  const responses = Array.from({ length: 4 }, () => ({
+    status: 400 as const,
+    body: { status: "error", code: 8502, message: "Operation failed." },
+  }));
+  const client = new PrintifyClient({
+    token: "tok",
+    shopId: "shop_42",
+    fetchImpl: makeFetch(calls, responses),
+    sleepImpl: noSleep,
+  });
+
+  await assert.rejects(
+    () => client.sendToProduction("po_1"),
+    (err: unknown) =>
+      err instanceof PrintifyError &&
+      err.status === 400 &&
+      (err.body as { code?: number } | undefined)?.code === 8502,
+  );
+  // initial attempt + 3 slow retries = 4 calls
+  assert.equal(calls.length, 4);
 });
 
 test("gives up after exhausting the retry schedule and throws PrintifyError", async () => {


### PR DESCRIPTION
## Summary
Live order `6f0ad214-d2f6-4246-8de3-99507fc52eda` failed today: `sendToProduction` returned HTTP 400 + Printify code 8502 ("Operation failed"). Manually retrying the same `printify_order_id` ~15 minutes later returned 202 and the order is now in production.

The race: Printify finishes print-file processing for our SVG upload after `createProduct` but before our `sendToProduction` call. Hitting `send_to_production` while the print provider is still rasterising trips 8502. The fast-retry budget (≤7.5s for 5xx/429) isn't long enough to ride this out.

## Change
Add a **slow-retry policy** to `PrintifyClient.request`:
- If the response is HTTP 400 and `body.code` is in `PRINTIFY_RETRYABLE_400_CODES` (just `8502` for now), back off on `[5s, 10s, 20s]` — ~35s total, comfortably inside the merch lambda's 60s timeout.
- Fast-retry policy for 5xx/429 is untouched.
- Independent attempt counters so a transient 5xx followed by an 8502 don't share a budget.

## Recovery (already done by hand)
- Order `6f0ad214…` flipped from `failed` → `submitted` in DynamoDB after Printify's `sending-to-production` ack.
- One affected order on the GSI; no other recovery needed.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — `printify.test.ts` adds 3 cases (8502 retried & succeeds, 400 with non-retryable code surfaces immediately, exhausted slow budget throws). 60/60 merch-related tests pass.
- [x] `npm run lambda:build` (bundle still builds clean)
- [ ] End-to-end: place a fresh paid order through the merch lambda after deploy and confirm the 8502-then-success path actually resolves on its own.

## Follow-ups (not in this PR)
- Could add a short post-`createOrder` sleep instead of waiting for the failure, but that pessimises the happy path.
- Could move retries out of the synchronous lambda invocation onto an EventBridge / SQS retry trigger to handle outages > 35s. Worth doing if 8502 keeps happening even after this fix.

https://claude.ai/code/session_01WeatxLKpew9vA8VBdcZm5C

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeatxLKpew9vA8VBdcZm5C)_