### PR TITLE
drawing page: humanize the meta panel, hide tech fields behind Advanced (#134)

### DIFF
--- a/builder/templates/drawing.ts
+++ b/builder/templates/drawing.ts
@@ -15,6 +15,27 @@ export interface DrawingView {
   repo_url: string;
 }
 
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+// Locale-neutral, server-renderable formatting of an ISO timestamp.
+// Output is UTC-anchored on purpose — the static HTML can't follow the
+// viewer's timezone without JS, and showing the same string everywhere
+// avoids the minor confusion of "I made this at 4 AM but the page says
+// 9 AM". Exported for unit tests.
+export function formatCreatedAt(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const month = MONTHS[d.getUTCMonth()];
+  const day = d.getUTCDate();
+  const year = d.getUTCFullYear();
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mm = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${month} ${day}, ${year} · ${hh}:${mm} UTC`;
+}
+
 export default function renderDrawing(v: DrawingView): string {
   const parentBlock = v.parent
     ? `<dt>parent</dt><dd><a href="/d/${esc(v.parent.parent)}">${esc(v.parent.parent_short)}</a></dd>`
@@ -22,6 +43,7 @@ export default function renderDrawing(v: DrawingView): string {
   const ownerBlock = v.owner
     ? `<dt>owner</dt><dd><a href="/keys/${esc(v.owner.pubkey)}">${esc(v.owner.pubkey_short)}</a></dd>`
     : `<dt>owner</dt><dd>anonymous</dd>`;
+  const created = formatCreatedAt(v.created_at);
   return `<!doctype html>
 <html lang="en">
   <head>
@@ -37,10 +59,8 @@ export default function renderDrawing(v: DrawingView): string {
     </header>
     <main class="drawing-page">
       <img src="/drawings/${esc(v.id)}.gif" alt="drawing ${esc(v.id_short)}" width="320" height="320" />
-      <dl>
-        <dt>id</dt><dd><code>${esc(v.id)}</code></dd>
-        <dt>minted</dt><dd>${esc(v.created_at)}</dd>
-        <dt>proof of work</dt><dd>${esc(v.required_bits)} bits in ${esc(v.solve_ms)}ms (${esc(v.bench_hps)} hps)</dd>
+      <p class="created-at">Created <time datetime="${esc(v.created_at)}">${esc(created)}</time></p>
+      <dl class="meta">
         ${ownerBlock}
         ${parentBlock}
       </dl>
@@ -53,6 +73,14 @@ export default function renderDrawing(v: DrawingView): string {
       <p>
         <a href="/share?d=${esc(v.id)}" rel="nofollow noreferrer">share to Reddit</a>
       </p>
+      <details class="advanced">
+        <summary>Advanced</summary>
+        <dl>
+          <dt>id</dt><dd><code>${esc(v.id)}</code></dd>
+          <dt>minted</dt><dd><code>${esc(v.created_at)}</code></dd>
+          <dt>proof of work</dt><dd>${esc(v.required_bits)} bits in ${esc(v.solve_ms)}ms (${esc(v.bench_hps)} hps)</dd>
+        </dl>
+      </details>
     </main>
     <footer>
       <a href="${esc(v.repo_url)}" target="_blank" rel="noopener">source on github</a>

--- a/static/gallery.css
+++ b/static/gallery.css
@@ -44,9 +44,35 @@ main { margin-top: 1rem; }
   background: #000;
   border: 1px solid var(--border);
 }
+.drawing-page .created-at {
+  margin: 0.75rem 0 1rem;
+  color: #ccc;
+}
+.drawing-page .created-at time {
+  color: var(--fg);
+}
 .drawing-page dl { display: grid; grid-template-columns: 8rem 1fr; gap: 0.25rem 1rem; }
 .drawing-page dt { color: #888; }
 .drawing-page code { word-break: break-all; }
+.drawing-page details.advanced {
+  margin-top: 1.5rem;
+  border-top: 1px solid var(--border);
+  padding-top: 0.75rem;
+}
+.drawing-page details.advanced summary {
+  cursor: pointer;
+  color: #888;
+  user-select: none;
+  list-style: none;
+}
+.drawing-page details.advanced summary::-webkit-details-marker { display: none; }
+.drawing-page details.advanced summary::before {
+  content: "▸ ";
+  display: inline-block;
+  width: 1ch;
+}
+.drawing-page details.advanced[open] summary::before { content: "▾ "; }
+.drawing-page details.advanced dl { margin-top: 0.5rem; }
 
 footer {
   margin-top: 2rem;

--- a/test/drawing-template.test.ts
+++ b/test/drawing-template.test.ts
@@ -1,0 +1,84 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import renderDrawing, { formatCreatedAt } from "../builder/templates/drawing.js";
+
+const baseView = {
+  id: "f".repeat(64),
+  id_short: "ffffffff",
+  created_at: "2026-05-08T04:24:56.088Z",
+  required_bits: 14,
+  solve_ms: 2,
+  bench_hps: 82335,
+  parent: null,
+  owner: { pubkey: "a".repeat(64), pubkey_short: "aaaaaaaa" },
+  repo_url: "https://github.com/example/drawbang",
+};
+
+test("formatCreatedAt: produces a UTC-anchored, locale-neutral string", () => {
+  assert.equal(
+    formatCreatedAt("2026-05-08T04:24:56.088Z"),
+    "May 8, 2026 · 04:24 UTC",
+  );
+  assert.equal(
+    formatCreatedAt("2026-12-31T23:59:00.000Z"),
+    "December 31, 2026 · 23:59 UTC",
+  );
+  assert.equal(
+    formatCreatedAt("2026-01-01T00:00:00.000Z"),
+    "January 1, 2026 · 00:00 UTC",
+  );
+});
+
+test("formatCreatedAt: returns the input verbatim on unparseable strings", () => {
+  assert.equal(formatCreatedAt("not-a-date"), "not-a-date");
+});
+
+test("drawing page: friendly date is up front", () => {
+  const html = renderDrawing(baseView);
+  assert.match(html, /<p class="created-at">Created <time datetime="2026-05-08T04:24:56\.088Z">May 8, 2026 · 04:24 UTC<\/time><\/p>/);
+});
+
+test("drawing page: hash and proof-of-work live inside the Advanced disclosure", () => {
+  const html = renderDrawing(baseView);
+  // <details> precedes any of the technical fields, and they all sit
+  // inside it. The order check guards against accidentally promoting one
+  // back into the main flow.
+  const detailsIdx = html.indexOf('<details class="advanced">');
+  const closeIdx = html.indexOf("</details>", detailsIdx);
+  assert.ok(detailsIdx > -1 && closeIdx > detailsIdx, "advanced section missing");
+  const inside = html.slice(detailsIdx, closeIdx);
+  assert.match(inside, /<dt>id<\/dt><dd><code>f{64}<\/code><\/dd>/);
+  assert.match(inside, /<dt>minted<\/dt><dd><code>2026-05-08T04:24:56\.088Z<\/code><\/dd>/);
+  assert.match(inside, /<dt>proof of work<\/dt><dd>14 bits in 2ms \(82335 hps\)<\/dd>/);
+
+  // And nothing technical leaks above the disclosure.
+  const before = html.slice(0, detailsIdx);
+  assert.doesNotMatch(before, /<dt>id<\/dt>/);
+  assert.doesNotMatch(before, /<dt>minted<\/dt>/);
+  assert.doesNotMatch(before, /proof of work/);
+});
+
+test("drawing page: owner link stays in the main flow (above the Advanced disclosure)", () => {
+  const html = renderDrawing(baseView);
+  const ownerIdx = html.indexOf("<dt>owner</dt>");
+  const detailsIdx = html.indexOf('<details class="advanced">');
+  assert.ok(ownerIdx > -1 && detailsIdx > -1);
+  assert.ok(ownerIdx < detailsIdx, "owner link should be above the Advanced disclosure");
+});
+
+test("drawing page: anonymous owner renders without an Advanced section regression", () => {
+  const html = renderDrawing({ ...baseView, owner: null });
+  assert.match(html, /<dt>owner<\/dt><dd>anonymous<\/dd>/);
+  assert.match(html, /<details class="advanced">/);
+});
+
+test("drawing page: parent link (when present) sits in the main flow", () => {
+  const html = renderDrawing({
+    ...baseView,
+    parent: { parent: "c".repeat(64), parent_short: "cccccccc" },
+  });
+  const parentIdx = html.indexOf("<dt>parent</dt>");
+  const detailsIdx = html.indexOf('<details class="advanced">');
+  assert.ok(parentIdx > -1 && parentIdx < detailsIdx);
+  assert.match(html, /<dd><a href="\/d\/c{64}">cccccccc<\/a><\/dd>/);
+});


### PR DESCRIPTION
Closes #134.

## Before
On first paint the drawing page led with three pieces of jargon:

```
id           f56026a53427d28f4e761274aaf68a2237b0f2a616e8bf07bde97c1b968ffbac
minted       2026-05-08T04:24:56.088Z
proof of work 14 bits in 2ms (82335 hps)
```

That's the most-quoted complaint from the design audit ("data dump, not information"). Every shared link lands here, so it's also the highest-leverage page to fix.

## After
- **Up front**: a friendly UTC-anchored date — `Created May 8, 2026 · 04:24 UTC` — plus the existing `owner` / `parent` links and the `fork` / `make merch` / `share to Reddit` actions.
- **Behind `<details>Advanced</details>`**: the same `id` / raw ISO `minted` / proof-of-work line. One click away, no data lost.

Server-side formatting only (the page is static HTML, no JS). The friendly date is wrapped in `<time datetime="…">` for accessibility and machine parseability.

## Why no "by you · 1 frame"
The audit suggested `Created May 8, 4:24 AM by you · 1 frame`. Two reasons that's deferred:
- **"by you"** depends on a creator-handle concept (#136). Showing the raw 64-char pubkey would defeat the point of this PR; once #136 lands, fold it in.
- **frame count** isn't on `DrawingMetadata` yet — ingest validates it but doesn't persist it. Trivial follow-up; opening as a separate issue rather than expanding scope here.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — `test/drawing-template.test.ts` adds 7 cases (date format edge cases, hash/PoW/ISO live inside disclosure, owner & parent positioning, anonymous-owner regression). All 35 fast tests pass.
- [x] `npm run lambda:build` — the ingest lambda imports the same template; bundle still builds clean.
- [x] Rendered a fixture page (`renderDrawing(...)`) and visually confirmed the layout.

## Sample output

```
<main class="drawing-page">
  <img src="/drawings/<id>.gif" alt="drawing f56026a5" width="320" height="320" />
  <p class="created-at">Created <time datetime="2026-05-08T04:24:56.088Z">May 8, 2026 · 04:24 UTC</time></p>
  <dl class="meta">
    <dt>owner</dt><dd><a href="/keys/<pubkey>">aaaaaaaa</a></dd>
  </dl>
  <p><a href="/?fork=<id>">fork this drawing</a></p>
  <p><a href="/merch?d=<id>&frame=0">make merch</a></p>
  <p><a href="/share?d=<id>">share to Reddit</a></p>
  <details class="advanced">
    <summary>Advanced</summary>
    <dl>
      <dt>id</dt><dd><code><id></code></dd>
      <dt>minted</dt><dd><code>2026-05-08T04:24:56.088Z</code></dd>
      <dt>proof of work</dt><dd>14 bits in 2ms (82335 hps)</dd>
    </dl>
  </details>
</main>
```

https://claude.ai/code/session_01WeatxLKpew9vA8VBdcZm5C

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeatxLKpew9vA8VBdcZm5C)_