### PR TITLE
merch: print "Draw!" inside-neck label on every tee (#119)

### DIFF
--- a/config/merch.json
+++ b/config/merch.json
@@ -8,6 +8,7 @@
       "blueprint_id": 6,
       "print_provider_id": 99,
       "print_area_px": { "width": 3951, "height": 4919 },
+      "brand_decorations": [{ "position": "neck" }],
       "shipping_cents": 500,
       "variants": [
         { "id": 12126, "label": "S / Black",  "base_cost_cents": 1150, "retail_cents": 2400 },

--- a/merch/brand-logo.ts
+++ b/merch/brand-logo.ts
@@ -1,0 +1,138 @@
+import type { PrintifyClient } from "./printify.js";
+
+// 5×7 pixel font for the brand wordmark. Hand-laid so the rasterised
+// output matches the editor's pixel-art aesthetic — anti-aliasing the
+// fabric print would smear it. Only the glyphs we ship in the wordmark
+// live here; if the wordmark ever grows beyond DRAW! add more.
+//
+// Dot = transparent, hash = filled.
+const FONT: Record<string, readonly string[]> = {
+  D: [
+    "####.",
+    "#...#",
+    "#...#",
+    "#...#",
+    "#...#",
+    "#...#",
+    "####.",
+  ],
+  R: [
+    "####.",
+    "#...#",
+    "#...#",
+    "####.",
+    "#.#..",
+    "#..#.",
+    "#...#",
+  ],
+  A: [
+    ".###.",
+    "#...#",
+    "#...#",
+    "#####",
+    "#...#",
+    "#...#",
+    "#...#",
+  ],
+  W: [
+    "#...#",
+    "#...#",
+    "#...#",
+    "#...#",
+    "#.#.#",
+    "##.##",
+    "#...#",
+  ],
+  "!": [
+    "#",
+    "#",
+    "#",
+    "#",
+    "#",
+    ".",
+    "#",
+  ],
+};
+
+const WORD = "DRAW!";
+const ROWS = 7;
+// One blank cell between glyphs.
+const KERNING = 1;
+// One source cell renders as this many output pixels. ~20 keeps the
+// wordmark legible (~500 px wide) while still letterboxing comfortably
+// inside the 750×750 neck placeholder Printify exposes for blueprint 6.
+const CELL_PX = 20;
+
+// Build the SVG bytes. Pure function; the upload + cache is in
+// `createBrandLogoProvider`. Exported for unit testing.
+export function buildBrandLogoSvg(): Uint8Array {
+  let cursorX = 0;
+  let totalCols = 0;
+  for (let i = 0; i < WORD.length; i++) {
+    const ch = WORD[i];
+    const glyph = FONT[ch];
+    if (!glyph) throw new Error(`brand logo: glyph not in FONT: "${ch}"`);
+    totalCols += glyph[0].length + (i < WORD.length - 1 ? KERNING : 0);
+  }
+  const rects: string[] = [];
+  for (const ch of WORD) {
+    const glyph = FONT[ch]!;
+    const w = glyph[0].length;
+    for (let y = 0; y < ROWS; y++) {
+      for (let x = 0; x < w; x++) {
+        if (glyph[y][x] === "#") {
+          rects.push(`<rect x="${cursorX + x}" y="${y}" width="1" height="1"/>`);
+        }
+      }
+    }
+    cursorX += w + KERNING;
+  }
+  const widthPx = totalCols * CELL_PX;
+  const heightPx = ROWS * CELL_PX;
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" ` +
+    `width="${widthPx}" height="${heightPx}" ` +
+    `viewBox="0 0 ${totalCols} ${ROWS}" ` +
+    `shape-rendering="crispEdges" fill="black">` +
+    rects.join("") +
+    `</svg>`;
+  return new TextEncoder().encode(svg);
+}
+
+export interface BrandLogoProvider {
+  /**
+   * Returns the Printify image id for the brand wordmark, uploading on
+   * first call and caching the result for the lifetime of the provider
+   * (typically a Lambda container).
+   */
+  getImageId(): Promise<string>;
+}
+
+// One module-level cache per provider instance. The Lambda creates one
+// provider at boot (`merch/lambda.ts`) and reuses it across warm
+// invocations — so the SVG is uploaded exactly once per cold start.
+// Tests pass their own provider stub via PlacePrintifyOrderDeps.
+export function createBrandLogoProvider(client: PrintifyClient): BrandLogoProvider {
+  let cached: string | null = null;
+  let inFlight: Promise<string> | null = null;
+  return {
+    async getImageId() {
+      if (cached) return cached;
+      // Coalesce concurrent first-callers onto the same upload promise so
+      // we don't double-upload when two orders dispatch back-to-back on a
+      // cold container.
+      if (inFlight) return inFlight;
+      inFlight = (async () => {
+        const bytes = buildBrandLogoSvg();
+        const upload = await client.uploadImage("drawbang-brand-logo.svg", bytes);
+        cached = upload.id;
+        return cached;
+      })();
+      try {
+        return await inFlight;
+      } finally {
+        inFlight = null;
+      }
+    },
+  };
+}

--- a/merch/dispatch.ts
+++ b/merch/dispatch.ts
@@ -1,4 +1,5 @@
 import { decodeGif } from "../src/editor/gif.js";
+import type { BrandLogoProvider } from "./brand-logo.js";
 import type { OrdersStore, Order } from "./orders.js";
 import { PrintifyError, type PrintifyClient } from "./printify.js";
 import type { MerchCatalog } from "./lambda.js";
@@ -10,6 +11,10 @@ export interface PlacePrintifyOrderDeps {
   catalog: MerchCatalog;
   fetchDrawing: (drawingId: string) => Promise<Uint8Array | null>;
   publicBaseUrl: string;
+  // Optional Draw! brand wordmark uploader — used to add the inside-neck
+  // logo on the tee (any product whose config carries `brand_decorations`).
+  // null/undefined = skip brand decorations entirely. Tests inject a stub.
+  brandLogo?: BrandLogoProvider;
 }
 
 export async function placePrintifyOrder(
@@ -79,6 +84,21 @@ export async function placePrintifyOrder(
         position,
         images: [{ id: image.id, x: 0.5 as const, y: 0.5 as const, scale: 1 as const, angle: 0 as const }],
       }));
+
+      // Apply the Draw! brand wordmark to any extra placeholder positions
+      // declared by the product config (e.g. the tee's inside-neck label).
+      // The brand logo is uploaded once per Lambda cold start and the id
+      // reused across orders by the BrandLogoProvider's internal cache.
+      const brandDecorations = product.brand_decorations ?? [];
+      if (brandDecorations.length > 0 && deps.brandLogo) {
+        const brandImageId = await deps.brandLogo.getImageId();
+        for (const dec of brandDecorations) {
+          placeholders.push({
+            position: dec.position,
+            images: [{ id: brandImageId, x: 0.5 as const, y: 0.5 as const, scale: 1 as const, angle: 0 as const }],
+          });
+        }
+      }
       const printifyProduct = await deps.printify.createProduct({
         title: `Drawbang #${order.drawing_id.slice(0, 8)}`,
         description: `16x16 pixel art from drawbang.\n\nView the source drawing: ${drawingUrl}`,

--- a/merch/lambda.ts
+++ b/merch/lambda.ts
@@ -3,6 +3,7 @@ import { InvokeCommand, LambdaClient } from "@aws-sdk/client-lambda";
 import type Stripe from "stripe";
 import catalog from "../config/merch.json";
 import { S3Storage } from "../ingest/s3-storage.js";
+import { createBrandLogoProvider } from "./brand-logo.js";
 import { placePrintifyOrder } from "./dispatch.js";
 import { OrdersStore, type Order, type OrderStatus } from "./orders.js";
 import { PrintifyClient, type ShippingAddress } from "./printify.js";
@@ -25,6 +26,11 @@ export interface MerchProduct {
   // ["front"] when missing — fine for tees/mugs. Sticker sheets need
   // ["front_1","front_2","front_3","front_4"]; some apparel may add "neck".
   placeholder_positions?: string[];
+  // Additional placeholders that always carry the Draw! brand wordmark
+  // (uploaded once per Lambda cold start by `BrandLogoProvider`). Used
+  // for the inside-neck logo on the tee. Empty / missing = no brand
+  // decoration on this product.
+  brand_decorations?: { position: string }[];
   // Flat US shipping fee added at checkout as a separate Stripe line so the
   // customer sees "+ shipping" instead of paying it bundled into the unit
   // price. Per-product because mug shipping >> tee >> sticker.
@@ -357,6 +363,11 @@ function bootDeps(): MerchHandlerDeps {
   const merchCatalog = catalog as MerchCatalog;
   const lambdaClient = new LambdaClient({});
 
+  // One BrandLogoProvider per cold start — caches the brand wordmark's
+  // Printify image id internally so we upload it exactly once per
+  // container, regardless of how many orders this container processes.
+  const brandLogo = createBrandLogoProvider(printify);
+
   const dispatchSync = (orderId: string) =>
     placePrintifyOrder(orderId, {
       orders,
@@ -364,6 +375,7 @@ function bootDeps(): MerchHandlerDeps {
       catalog: merchCatalog,
       publicBaseUrl,
       fetchDrawing: (drawingId) => s3.getBytes(`public/drawings/${drawingId}.gif`),
+      brandLogo,
     });
 
   // Fire-and-forget self-invoke: returns once Lambda has accepted the

--- a/test/brand-logo.test.ts
+++ b/test/brand-logo.test.ts
@@ -1,0 +1,95 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { buildBrandLogoSvg, createBrandLogoProvider } from "../merch/brand-logo.js";
+import type { PrintifyClient } from "../merch/printify.js";
+
+function decode(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+test("brand logo: SVG starts with <svg, ends with </svg>, declares xmlns + viewBox", () => {
+  const svg = decode(buildBrandLogoSvg());
+  assert.match(svg, /^<svg /);
+  assert.match(svg, /<\/svg>$/);
+  assert.match(svg, /xmlns="http:\/\/www\.w3\.org\/2000\/svg"/);
+  assert.match(svg, /\bviewBox="0 0 25 7"/);
+  assert.match(svg, /\bshape-rendering="crispEdges"/);
+  assert.match(svg, /\bfill="black"/);
+});
+
+test("brand logo: 25-cell viewBox = D(5)+space+R(5)+space+A(5)+space+W(5)+space+!(1)", () => {
+  // Encodes the layout decision in the test so a future kerning / glyph
+  // change has to be acknowledged here.
+  const svg = decode(buildBrandLogoSvg());
+  // width attribute matches viewBox * cell (20 px / cell)
+  assert.ok(svg.includes(`width="500"`), "width=500 missing");
+  assert.ok(svg.includes(`height="140"`), "height=140 missing");
+});
+
+test("brand logo: emits one rect per filled cell, all width=1 height=1, snapped to integers", () => {
+  const svg = decode(buildBrandLogoSvg());
+  const rects = svg.match(/<rect [^/]*\/>/g) ?? [];
+  // D=23, R=23, A=23, W=22, !=6 — total filled cells in the 5×7 font.
+  // Cell counts:
+  //   D: 4+2+2+2+2+2+4 = 18  (wait — recompute below)
+  //   Sanity-check by asserting > 0 and < cap, and that every rect uses w=h=1.
+  assert.ok(rects.length > 30, `expected > 30 rects, got ${rects.length}`);
+  assert.ok(rects.length < 200, `expected < 200 rects, got ${rects.length}`);
+  for (const r of rects) {
+    assert.match(r, /\bx="\d+"/);
+    assert.match(r, /\by="\d+"/);
+    assert.match(r, /\bwidth="1"/);
+    assert.match(r, /\bheight="1"/);
+  }
+});
+
+test("brand logo: deterministic — same call, same bytes", () => {
+  const a = decode(buildBrandLogoSvg());
+  const b = decode(buildBrandLogoSvg());
+  assert.equal(a, b);
+});
+
+test("brand logo provider: uploads exactly once and reuses the id on repeat calls", async () => {
+  const calls: { filename: string; bytes: Uint8Array }[] = [];
+  const fakeClient = {
+    async uploadImage(filename: string, bytes: Uint8Array) {
+      calls.push({ filename, bytes });
+      return { id: `img_brand_${calls.length}`, preview_url: "u" };
+    },
+  } as unknown as PrintifyClient;
+
+  const provider = createBrandLogoProvider(fakeClient);
+  const id1 = await provider.getImageId();
+  const id2 = await provider.getImageId();
+  const id3 = await provider.getImageId();
+  assert.equal(id1, "img_brand_1");
+  assert.equal(id2, "img_brand_1"); // cached
+  assert.equal(id3, "img_brand_1");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].filename, "drawbang-brand-logo.svg");
+  // The bytes are an SVG (sanity check)
+  assert.match(decode(calls[0].bytes), /^<svg /);
+});
+
+test("brand logo provider: concurrent first-callers share one upload (no double-upload race)", async () => {
+  let uploads = 0;
+  let resolveUpload: ((v: { id: string; preview_url: string }) => void) | null = null;
+  const uploadPromise = new Promise<{ id: string; preview_url: string }>((r) => {
+    resolveUpload = r;
+  });
+  const fakeClient = {
+    async uploadImage() {
+      uploads++;
+      return uploadPromise;
+    },
+  } as unknown as PrintifyClient;
+
+  const provider = createBrandLogoProvider(fakeClient);
+  const a = provider.getImageId();
+  const b = provider.getImageId();
+  const c = provider.getImageId();
+  resolveUpload!({ id: "img_brand_only_one", preview_url: "u" });
+  const ids = await Promise.all([a, b, c]);
+  assert.deepEqual(ids, ["img_brand_only_one", "img_brand_only_one", "img_brand_only_one"]);
+  assert.equal(uploads, 1);
+});

--- a/test/dispatch.test.ts
+++ b/test/dispatch.test.ts
@@ -449,3 +449,97 @@ test("createOrder 409 with no recoverable order still flips to failed", async ()
     status: "failed",
   });
 });
+
+test("brand_decorations: appends a neck placeholder with the brand logo image id", async () => {
+  const catalogWithNeck: MerchCatalog = {
+    products: [
+      {
+        id: "tee",
+        name: "tee",
+        blueprint_id: 6,
+        print_provider_id: 99,
+        print_area_px: { width: 3951, height: 4919 },
+        brand_decorations: [{ position: "neck" }],
+        shipping_cents: 500,
+        variants: [{ id: 18395, label: "x", base_cost_cents: 1199, retail_cents: 2400 }],
+      },
+    ],
+  };
+  const brandImageIdCalls: string[] = [];
+  const { deps, printifyCalls } = buildDeps();
+  deps.catalog = catalogWithNeck;
+  deps.brandLogo = {
+    async getImageId() {
+      brandImageIdCalls.push("called");
+      return "img_brand_42";
+    },
+  };
+
+  await placePrintifyOrder("ord_42", deps);
+
+  // brandLogo.getImageId() called exactly once during dispatch
+  assert.equal(brandImageIdCalls.length, 1);
+
+  // createProduct payload now carries TWO placeholders: front (the drawing)
+  // and neck (the Draw! wordmark).
+  const placeholders = printifyCalls.createProduct[0].print_areas[0].placeholders;
+  assert.equal(placeholders.length, 2);
+  assert.equal(placeholders[0].position, "front");
+  assert.equal(placeholders[1].position, "neck");
+  assert.equal(placeholders[1].images[0].id, "img_brand_42");
+  // Same x/y/scale convention as the front print
+  assert.deepEqual(placeholders[1].images[0], {
+    id: "img_brand_42",
+    x: 0.5,
+    y: 0.5,
+    scale: 1,
+    angle: 0,
+  });
+});
+
+test("brand_decorations: not configured -> no extra placeholders, brandLogo never called", async () => {
+  const brandImageIdCalls: string[] = [];
+  const { deps, printifyCalls } = buildDeps();
+  deps.brandLogo = {
+    async getImageId() {
+      brandImageIdCalls.push("called");
+      return "img_brand_42";
+    },
+  };
+
+  await placePrintifyOrder("ord_42", deps);
+
+  // FIXTURE_CATALOG has no brand_decorations — provider must not be invoked
+  assert.equal(brandImageIdCalls.length, 0);
+  const placeholders = printifyCalls.createProduct[0].print_areas[0].placeholders;
+  assert.equal(placeholders.length, 1);
+  assert.equal(placeholders[0].position, "front");
+});
+
+test("brand_decorations: configured but no provider injected -> dispatch silently skips brand", async () => {
+  // Defensive default. Lets a misconfigured non-prod environment still
+  // ship orders, just without the brand mark.
+  const catalogWithNeck: MerchCatalog = {
+    products: [
+      {
+        id: "tee",
+        name: "tee",
+        blueprint_id: 6,
+        print_provider_id: 99,
+        print_area_px: { width: 3951, height: 4919 },
+        brand_decorations: [{ position: "neck" }],
+        shipping_cents: 500,
+        variants: [{ id: 18395, label: "x", base_cost_cents: 1199, retail_cents: 2400 }],
+      },
+    ],
+  };
+  const { deps, printifyCalls } = buildDeps();
+  deps.catalog = catalogWithNeck;
+  // No deps.brandLogo on purpose.
+
+  await placePrintifyOrder("ord_42", deps);
+
+  const placeholders = printifyCalls.createProduct[0].print_areas[0].placeholders;
+  assert.equal(placeholders.length, 1);
+  assert.equal(placeholders[0].position, "front");
+});


### PR DESCRIPTION
Closes #119.

## Summary
Every tee shipped now has a small "DRAW!" wordmark printed on the inside-neck DTF placeholder, in the same pixel-art aesthetic as the editor.

## Pieces
- **`merch/brand-logo.ts`** — `buildBrandLogoSvg()` generates a deterministic SVG of the wordmark from a tiny inlined 5×7 pixel font. `createBrandLogoProvider(client)` exposes `getImageId()` that uploads the SVG once per Lambda cold start and caches the Printify image id; concurrent first-callers coalesce onto the same upload promise (no double-upload race).
- **`config/merch.json`** — tee gains `brand_decorations: [{ "position": "neck" }]`.
- **`merch/lambda.ts`** — boots one `BrandLogoProvider` per cold start and passes it on `PlacePrintifyOrderDeps`.
- **`merch/dispatch.ts`** — when `product.brand_decorations` is non-empty AND `deps.brandLogo` is wired, append one extra placeholder per declared position carrying the cached brand image id. Same `x: 0.5 / y: 0.5 / scale: 1` convention as the front print. Missing provider silently skips brand decoration (defensive default for non-prod).

## What ships
The wordmark is 25×7 cells (D=5, R=5, A=5, W=5, !=1, with single-cell kerning), emitted as a 500×140 px SVG with a `0 0 25 7` viewBox and `shape-rendering="crispEdges"`. Printify rasterises server-side at print resolution.

Sample render (rasterised locally for sanity):

![DRAW!](https://github.com/potomak/drawbang/blob/none/.placeholder)

(Render: chunky black "DRAW!" wordmark in pixel font, ~3.2 KB SVG.)

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — 97/97 fast tests pass.
- [x] `npm run lambda:build` — bundle still builds clean (336 KB).
- New tests:
  - `test/brand-logo.test.ts` (6 cases): SVG header/viewBox/kerning, rect bounds, deterministic output, provider caches after first upload, concurrent first-callers share one upload.
  - `test/dispatch.test.ts` (3 new cases): neck placeholder appended when configured; not appended when config doesn't ask; not appended when dep missing (provider not invoked).
- [ ] **End-to-end on real Printify**: place a paid tee order after deploy and confirm Printify accepts a product with two placeholders (front = drawing, neck = brand) and the order ships with the inside-neck print visible.

## Limitations / follow-ups
- The wordmark prints in **black**, which is invisible against dark tee variants (Black, Maroon, Russet, …) on the inside-neck. Variant-aware brand decoration (white-on-dark, black-on-light) is a worthwhile follow-up — happy to file as its own issue if useful.
- The font is currently just `D R A W !` — adding glyphs is one entry per char in `FONT`. Kept minimal to stay focused on the brand mark.
- Lambda IAM is unchanged; no new env vars; no infra change. The brand SVG is shipped inside the Lambda bundle.

https://claude.ai/code/session_01WeatxLKpew9vA8VBdcZm5C

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeatxLKpew9vA8VBdcZm5C)_