### PR TITLE
fix(editor): prevent page scroll while painting on mobile

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1459,6 +1459,13 @@ function pointerToPixel(ev: PointerEvent): { x: number; y: number } {
 mainCanvasEl.addEventListener("pointerdown", (ev) => {
   if (playing) return;
   ev.preventDefault();
+  if (!ev.isPrimary) return;
+  // Prevent the page from scrolling while painting on touch. `touch-action: none`
+  // on the canvas already blocks the browser's pan gesture, but pointer capture
+  // keeps the stream coherent when the finger leaves the canvas bounds.
+  try {
+    mainCanvasEl.setPointerCapture(ev.pointerId);
+  } catch {}
   if (tool === "move") {
     moveSnapshot = activeBitmap().clone();
     moveStart = mainCanvas.quantizeUnclamped(ev.clientX, ev.clientY);
@@ -1471,6 +1478,7 @@ mainCanvasEl.addEventListener("pointerdown", (ev) => {
   applyTool(x, y);
 });
 window.addEventListener("pointermove", (ev) => {
+  if (!ev.isPrimary) return;
   if (moveSnapshot && moveStart) {
     const p = mainCanvas.quantizeUnclamped(ev.clientX, ev.clientY);
     const dx = p.x - moveStart.x;
@@ -1485,7 +1493,15 @@ window.addEventListener("pointermove", (ev) => {
   const { x, y } = pointerToPixel(ev);
   applyTool(x, y);
 });
-window.addEventListener("pointerup", () => {
+function releaseCapture(ev: PointerEvent): void {
+  if (mainCanvasEl.hasPointerCapture(ev.pointerId)) {
+    try {
+      mainCanvasEl.releasePointerCapture(ev.pointerId);
+    } catch {}
+  }
+}
+window.addEventListener("pointerup", (ev: PointerEvent) => {
+  if (ev.isPrimary) releaseCapture(ev);
   if (moveSnapshot && moveStart) {
     endMoveDrag();
     return;
@@ -1494,14 +1510,35 @@ window.addEventListener("pointerup", () => {
   painting = false;
   endStroke();
 });
-window.addEventListener("pointercancel", () => {
+window.addEventListener("pointercancel", (ev: PointerEvent) => {
+  if (ev.isPrimary) releaseCapture(ev);
   if (moveSnapshot && moveStart) {
-    endMoveDrag();
+    // Cancel the in-flight move — don't commit a translate, just discard.
+    moveSnapshot = null;
+    moveStart = null;
+    moveLastDelta = { dx: 0, dy: 0 };
+    render();
     return;
   }
   if (!painting) return;
   painting = false;
-  endStroke();
+  // Don't push a stroke on cancel — the gesture was aborted.
+  strokeSnapshot = null;
+  strokeDirty = false;
+});
+mainCanvasEl.addEventListener("lostpointercapture", () => {
+  // Fallback if capture is lost without an explicit up/cancel (e.g. alert).
+  if (moveSnapshot && moveStart) {
+    moveSnapshot = null;
+    moveStart = null;
+    moveLastDelta = { dx: 0, dy: 0 };
+    render();
+  }
+  if (painting) {
+    painting = false;
+    strokeSnapshot = null;
+    strokeDirty = false;
+  }
 });
 
 function endMoveDrag(): void {

--- a/src/style.css
+++ b/src/style.css
@@ -21,6 +21,16 @@ body {
   font-variant-ligatures: none;
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
+  /* Prevent pull-to-refresh / overscroll chaining while interacting with the
+     editor. The canvas itself uses touch-action:none, but the page still
+     participates in scroll chaining without this. */
+  overscroll-behavior-y: contain;
+  overflow-x: clip;
+}
+html {
+  /* Prevent horizontal scroll at the viewport level — frames toolbar overflow
+     should scroll inside its strip, not the page. */
+  overflow-x: clip;
 }
 svg, canvas { image-rendering: pixelated; image-rendering: crisp-edges; }
 


### PR DESCRIPTION
Fixes #246

Canvas drag on touch was panning the page and leaving gaps:

- `pointerdown` had no `isPrimary` guard or `setPointerCapture`, so finger leaving canvas lost coherence
- `window pointermove/up/cancel` had no capture release / lostcapture fallback → `moveSnapshot` stranded if `alert/confirm` fired mid-drag
- No `overscroll-behavior` / `overflow-x:clip` → pull-to-refresh and viewport horizontal scroll

Changes:
- `src/main.ts`: `setPointerCapture` on down, `releaseCapture` on up/cancel, `isPrimary` guards, `pointercancel` discards instead of committing, `lostpointercapture` fallback
- `src/style.css`: `overscroll-behavior-y:contain` + `html/body overflow-x:clip` (canvas already `touch-action:none`)

Verified: `npm run typecheck` ✓ (tsc -b --noEmit, zero errors) and `npm test` ✓ (818 tests, 0 fail) on node v22.20.0 with /tmp/node-v22. Manual touch test still needed on iOS Safari + Android Chrome — should drag to paint full stroke without page pan.

Related backlog: #247, #248 pending.
