### PR TITLE
fix(editor): wrap frames toolbar on mobile to prevent horizontal scroll

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -267,15 +267,24 @@ body > main, .app > main { display: block; }
   border-bottom: var(--border) solid var(--border-c);
   gap: 12px;
   flex-wrap: wrap;
+  min-width: 0;
 }
 .ed-frames-head .panel-h { margin: 0; }
-.ed-frames-meta { display: flex; gap: 8px; align-items: center; }
+.ed-frames-meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  min-width: 0;
+  max-width: 100%;
+}
 .ed-fps {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   font-size: var(--t-xs);
   color: var(--fg-muted);
+  flex-wrap: wrap;
 }
 .ed-fps input[type="range"] {
   width: 90px;


### PR DESCRIPTION
Fixes #247

.ed-frames-meta was `display:flex` without `flex-wrap`, so Copy/Paste/Copy PNG/Onion/Grid/Play/FPS buttons overflowed the viewport and caused horizontal page scroll on 320–430px (Issue 2).

Changes:
- `src/style.css`: `.ed-frames-head`/`.ed-frames-meta` add `flex-wrap:wrap` + `min-width:0` / `max-width:100%`
- `.ed-fps` also wrap

Verified: `npm run typecheck` ✓ (zero errors) on node v22.20.0. Manual: resize to 320px, no `document.documentElement.scrollWidth > innerWidth`.

Part of backlog #246-#254; follow-up is #248 (draft autosave).