### PR TITLE
docs: editor draft autosave + line tool (248, 261)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,14 @@ content-addressed by sha256 of the gif bytes:
 `drawing_id` is keyed by content; **PoW is gone**, and so is the login
 gate that briefly replaced it — see "Anonymous publishing".
 
+## Editor (`src/main.ts` + `src/editor/*` + `src/local.ts`)
+
+- **Sizes / layers / frames**: 8/16/32/64 (`DRAWING_SIZES`), `MAX_FRAMES=16`, `MAX_LAYERS` (UI + server 64 KiB `layers_json` cap). Frames hold one `Bitmap` per layer; `composeFrame` flattens for the GIF preview and the ingest payload.
+- **Tools**: Pencil (B) / Eraser (E) / Fill (G) / **Line (L)** / Move (V). Line uses `drawLine` (Bresenham, clipped) in `src/editor/tools.ts` — `pointerdown` snapshots the active `Bitmap` + records `lineStart`, `pointermove` restores the snapshot and draws the ghost line (with `mirrorX` when `symmetryH` is on), `pointerup` commits + pushes `history` + `persist()`, `pointercancel`/`lostpointercapture` restores the snapshot. Other strokes use `PixelPerfectStroke` when enabled.
+- **Draft autosave**: every `persist()` writes **two** stores: IndexedDB (`src/local.ts` `drawbang` DB, `drawings` store) *and* synchronous `localStorage` `drawbang:draft:{size}` (`{v,size,ts,frames: string[][] (base64 per layer), layers, activePalette, delayMs, localId, opLog}`) capped at `MAX_LAYERS_JSON_BYTES` (64 KiB). On boot without `?fork`/`#d`, `readDraft(currentSize)` shows `draftRestoreBanner` (Restore draft / Discard); `applyDraft` rehydrates `state`, `activePalette`, `delayMs`, `localId` and re-renders. Draft clears when the canvas becomes empty and on `resetEditor` / successful `POST /ingest` (publish).
+- **Navigate-away guard**: `beforeunload` (`if (hasUnsavedContent()) { writeDraft(); e.preventDefault(); e.returnValue=''; }`) and `visibilitychange` (`hidden` → `writeDraft`+`persist`) so Safari Reload / tab-close doesn’t lose work. `hasUnsavedContent()` is “any non-transparent pixel or multi-frame/layer”.
+- **Other persisted prefs** (all `try/catch localStorage`): `drawbang:palette`, `drawbang:grid`, `drawbang:pixel-perfect`, `drawbang:symmetry-h`.
+
 ## Deployment shape
 
 ```

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ npm run dev
 Vite serves the editor at <http://localhost:5173>. Hot-reload works for
 the editor / merch / share / order pages.
 
+The editor includes:
+- **Canvas sizes** 8/16/32/64, **layers** + **frames** (up to 16), FPS 4–12, onion skin, grid.
+- **Palettes** (retro picker + Lospec import + base 256), **tools** — Pencil (B), Eraser (E), Fill (G), **Line (L)** with ghost preview until release, Move (V) with wrap — plus pixel-perfect, horizontal symmetry, flip/rotate, undo/clear.
+- **Draft autosave** — every stroke/frame persists to IndexedDB *and* synchronously to `localStorage` `drawbang:draft:{size}` (≤64 KiB, same cap as the publish sidecar). On reload without `?fork`/`#d`, a “Restore draft?” banner recovers the drawing; `beforeunload` + `visibilitychange` flush the draft so Safari Reload / navigate-away doesn’t lose work. The draft clears on Publish or Clear.
+
 ### Run the ingest endpoint locally (against the filesystem)
 
 ```bash

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -175,6 +175,15 @@ The proxied path list now lives in `vite.config.ts` as `DEV_PROXY_PATHS`
 and is passed to both the proxy and the plugin. **Add new dev-server
 routes there**, not to the proxy alone.
 
+## Draft autosave + `beforeunload` + `visibilitychange`
+
+- The canvas has **two** draft stores: async IndexedDB (`src/local.ts` `drawbang` DB — the "My drawings" history) and sync `localStorage` `drawbang:draft:{size}` (the reload guard). The sync store must stay **synchronous** — `visibilitychange`/`beforeunload` have no time to `await` IndexedDB, so `writeDraft()` does a single `localStorage.setItem` and `persist()` calls it without awaiting.
+- Cap is `MAX_LAYERS_JSON_BYTES` (64 KiB). `writeDraft` measures `JSON.stringify(payload).length` and **skips** the write if it would exceed the cap; it does not truncate — a truncated JSON would not parse on restore. A drawing that exceeds the cap simply has no reload guard for that stroke (rare at 16×16).
+- `hasUnsavedContent()` is the gate for both guards. It checks for any non-transparent pixel **or** `frames.length>1`/`layers.length>1`. A blank multi-frame document still counts as unsaved — that’s intentional, losing a second frame is still data loss.
+- `beforeunload` must set **both** `e.preventDefault()` and `e.returnValue = ""` — some browsers require one, some the other, and Safari mobile only shows its dialog when `returnValue` is set to a non-null string. Don’t add a custom message string; modern browsers ignore it and show a generic prompt.
+- The restore banner (`#draftRestoreBanner`) only appears when **neither** `?fork=` nor `#d=` is present. In those cases the URL is the source of truth and a stale local draft would be wrong to surface. `readDraft` is keyed by `currentSize`, so a 32×32 draft never restores into a 16×16 session.
+- `resetEditor` clears the draft **before** re-applying the palette and calling `persist()` — `persist()` would otherwise see the fresh blank canvas, see `hasUnsavedContent()==false`, and remove the key anyway, but clearing explicitly makes the intent obvious and covers the publish path (`clearDraft()` before `resetEditor({keepPublishedId:true})`).
+
 ## Vite entries at nested clean URLs need absolute asset paths
 
 `/password/forgot` and `/password/reset` are the only Vite entries whose


### PR DESCRIPTION
Fixes docs drift for recent editor changes.

**What changed in code**
- #248 — draft autosave: IndexedDB + sync `localStorage` `drawbang:draft:{size}` (≤64 KiB), restore banner on reload without `?fork`/`#d`, `beforeunload` + `visibilitychange` guard.
- #261 — Line tool (L) with Bresenham ghost preview until `pointerup`.

**Docs**
- `README.md` — add Editor bullets under “Run the editor locally” (sizes/layers/frames/FPS, palettes, tools including Line ghost, draft autosave + banner + guard).
- `CLAUDE.md` — new `## Editor (src/main.ts + src/editor/* + src/local.ts)` section (sizes/layers/frames, tools/Line flow, dual-store draft + cap + banner, navigate-away guard, persisted prefs).
- `docs/gotchas.md` — new `## Draft autosave + beforeunload + visibilitychange` (dual stores, cap, gate, `returnValue` requirement, banner gating, explicit `clearDraft` in `resetEditor`).

Related: #227 (CLAUDE page tables — already synced; this adds the missing Editor section that #227 flagged as docs-only debt), #253 (shell drift — not in scope, left as P2).

No code, no test changes. `npm run typecheck`/`npm test` unaffected.