### PR TITLE
fix: deduplicate HTML-escape helpers to single shared module (#230)

### DIFF
--- a/lib/templates/_escape.ts
+++ b/lib/templates/_escape.ts
@@ -6,8 +6,6 @@ const ESC: Record<string, string> = {
   "'": "&#39;",
 };
 
-// TODO (#shared-escape): canonical copy; src/layout/chrome.ts and
-// src/order.ts carry duplicates (docs/architecture-review-2026-06.md).
 export function esc(v: unknown): string {
   if (v == null) return "";
   return String(v).replace(/[&<>"']/g, (c) => ESC[c]!);

--- a/src/layout/chrome.ts
+++ b/src/layout/chrome.ts
@@ -22,6 +22,7 @@
 
 import { assetUrl } from "./asset-version.js";
 import { LOGO_SVG } from "./logo.js";
+import { esc } from "../../lib/templates/_escape.js";
 
 export interface NavLink {
   href: string;
@@ -170,16 +171,4 @@ const FEEDBACK_URL =
 
 const MENU_ICON_SVG = `<svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square"><path d="M3 6h18M3 12h18M3 18h18"/></svg>`;
 
-const ESC: Record<string, string> = {
-  "&": "&amp;",
-  "<": "&lt;",
-  ">": "&gt;",
-  '"': "&quot;",
-  "'": "&#39;",
-};
-// TODO (#shared-escape): duplicate of lib/templates/_escape.ts esc() —
-// consolidate to one shared module (docs/architecture-review-2026-06.md).
-function esc(v: unknown): string {
-  if (v == null) return "";
-  return String(v).replace(/[&<>"']/g, (c) => ESC[c]!);
-}
+

--- a/src/order.ts
+++ b/src/order.ts
@@ -1,4 +1,5 @@
 import { tracker } from "./analytics/analytics.js";
+import { esc as escapeHtml } from "../lib/templates/_escape.js";
 
 interface OrderView {
   order_id?: string;
@@ -73,19 +74,7 @@ function formatUsd(cents: number | undefined): string {
   return `$${(cents / 100).toFixed(2)}`;
 }
 
-// TODO (#shared-escape): third copy of the HTML escaper — consolidate
-// with lib/templates/_escape.ts (docs/architecture-review-2026-06.md).
-function escapeHtml(s: string): string {
-  return s.replace(/[&<>"']/g, (ch) => {
-    switch (ch) {
-      case "&": return "&amp;";
-      case "<": return "&lt;";
-      case ">": return "&gt;";
-      case "\"": return "&quot;";
-      default: return "&#39;";
-    }
-  });
-}
+
 
 function renderRetry(msg: string, onRetry: () => void): void {
   cardEl.innerHTML = `


### PR DESCRIPTION
Closes #230

Consolidates three independent HTML-escapers onto the canonical `lib/templates/_escape.ts`:

- `src/layout/chrome.ts` — removed local `ESC`/`esc`, now `import { esc } from "../../lib/templates/_escape.js"`
- `src/order.ts` — removed `escapeHtml`, now `import { esc as escapeHtml } from "../lib/templates/_escape.js"` (call sites unchanged)
- `lib/templates/_escape.ts` — removed TODO marker, now canonical

No behavior change — same ESC map/regex. Verified:
- `/opt/facebook/jellyfish/node ./node_modules/typescript/bin/tsc -b --noEmit` pass
- `grep -rn "function esc\|escapeHtml" lib/templates src` now shows single definition

Risk: first `src/` → `lib/templates/` import; Vite bundler resolves relative .js; tsc verifies.

Related: #253 shell unification will further consolidate chrome helpers.