### PR TITLE
feat(merch): runtime admin toggle for dry-run — Stripe test vs live + Printify no-op (#274)

### DIFF
--- a/infra/aws/template.yaml
+++ b/infra/aws/template.yaml
@@ -43,6 +43,32 @@ Parameters:
     NoEcho: true
     Default: ""
     Description: Stripe webhook signing secret (whsec_…). Maps to STRIPE_WEBHOOK_SECRET.
+  # Dual Stripe key pairs for the merch dry-run toggle (#274 / #277).
+  # Live + Test variants let the merch Lambda pick the helper at request time
+  # based on the merch_dry_run flag in drawbang-flags. Kept alongside the
+  # legacy singular params so existing `sam deploy --parameter-overrides
+  # StripeSecretKey=…` deploys keep working — new code prefers _LIVE/_TEST
+  # and falls back to the singular value when _LIVE is empty.
+  StripeSecretKeyLive:
+    Type: String
+    NoEcho: true
+    Default: ""
+    Description: Stripe live secret key (sk_live_…). Maps to STRIPE_SECRET_KEY_LIVE. Falls back to STRIPE_SECRET_KEY when empty.
+  StripeSecretKeyTest:
+    Type: String
+    NoEcho: true
+    Default: ""
+    Description: Stripe test secret key (sk_test_…). Maps to STRIPE_SECRET_KEY_TEST.
+  StripeWebhookSecretLive:
+    Type: String
+    NoEcho: true
+    Default: ""
+    Description: Stripe live webhook signing secret (whsec_… live). Maps to STRIPE_WEBHOOK_SECRET_LIVE. Falls back to STRIPE_WEBHOOK_SECRET when empty.
+  StripeWebhookSecretTest:
+    Type: String
+    NoEcho: true
+    Default: ""
+    Description: Stripe test webhook signing secret (whsec_… test). Maps to STRIPE_WEBHOOK_SECRET_TEST.
   # HS256 signing secret for session + password-reset JWTs. No default — the
   # ingest function fails loud at cold start if unset, since every publish /
   # claim / auth route depends on it. Supply via parameter_overrides from a
@@ -793,6 +819,25 @@ Resources:
         AttributeName: expires_at
         Enabled: true
 
+  # -- Flags table for runtime admin toggles ----------------------------------
+  # drawbang-flags holds feature flags keyed by `flag` (PK). Project 2
+  # (#274 / #277) seeds the single item `merch_dry_run` — when true the
+  # merch dispatch path early-returns with `submitted dry-run` and skips
+  # Printify. Access via merch/flags-store.ts (getFlag/setFlag with 5 s
+  # in-memory cache and conditional writes). Admin toggle lives at
+  # GET /admin/merch/flags + POST /admin/merch/flags (allowlisted) in
+  # ingest/admin-handler.ts, ingest/routes.ts, lib/templates/admin.ts.
+  # On-demand billing, single-attribute key — no GSIs, no TTL.
+  FlagsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: drawbang-flags
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - { AttributeName: flag, AttributeType: S }
+      KeySchema:
+        - { AttributeName: flag, KeyType: HASH }
+
   # -- Ingest Lambda + API Gateway --------------------------------------------
 
   IngestFunction:
@@ -826,6 +871,13 @@ Resources:
           DRAWBANG_FOLLOWS_TABLE: !Ref FollowsTable
           DRAWBANG_SUBSCRIBERS_TABLE: !Ref SubscribersTable
           DRAWBANG_CHALLENGES_TABLE: !Ref ChallengesTable
+          # Flags table for the admin merch dry-run toggle (#274 / #277).
+          # merch/flags-store.ts reads this via FLAGS_TABLE /
+          # DRAWBANG_FLAGS_TABLE; the ingest admin handler (GET+POST
+          # /admin/merch/flags) writes it. Both names point to the same
+          # table so either env-var convention works across Lambdas.
+          FLAGS_TABLE: !Ref FlagsTable
+          DRAWBANG_FLAGS_TABLE: !Ref FlagsTable
           CF_DISTRIBUTION_ID: !Ref CloudFrontDistributionIdOverride
           JWT_SECRET: !Ref JwtSecret
           SES_FROM_ADDRESS: !Ref SesFromAddress
@@ -854,6 +906,13 @@ Resources:
         - DynamoDBCrudPolicy: { TableName: !Ref FollowsTable }
         - DynamoDBCrudPolicy: { TableName: !Ref SubscribersTable }
         - DynamoDBCrudPolicy: { TableName: !Ref ChallengesTable }
+        # Runtime flags for the merch dry-run toggle (#274 / #277). Ingest
+        # is the writer (POST /admin/merch/flags) and reader (GET
+        # /admin/merch/flags + lib/templates/admin.ts card); merch is the
+        # reader (merch/flags-store.ts getFlag with 5 s cache). Grant CRUD
+        # to ingest and at least CRUD to merch so conditional writes via
+        # getFlag/setFlag work from either Lambda without a second deploy.
+        - DynamoDBCrudPolicy: { TableName: !Ref FlagsTable }
         # The /products handler queries the merch popularity counters (the
         # MerchFunction is the writer; ingest only reads here).
         - DynamoDBReadPolicy: { TableName: !Ref ProductCountersTable }
@@ -1178,6 +1237,18 @@ Resources:
             ApiId: !Ref IngestApi
             Method: DELETE
             Path: /admin/users/{username}
+        AdminMerchFlagsGet:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref IngestApi
+            Method: GET
+            Path: /admin/merch/flags
+        AdminMerchFlagsPost:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref IngestApi
+            Method: POST
+            Path: /admin/merch/flags
 
   # Lambda auto-creates /aws/lambda/drawbang-ingest with infinite retention
   # on first invocation. Apply a 90-day cap once via the AWS CLI so the
@@ -1250,10 +1321,24 @@ Resources:
         Variables:
           ORDERS_TABLE: !Ref OrdersTable
           PRODUCT_COUNTERS_TABLE: !Ref ProductCountersTable
+          # Runtime feature flags (drawbang-flags). merch/flags-store.ts
+          # reads FLAGS_TABLE / DRAWBANG_FLAGS_TABLE with a 5 s in-memory
+          # cache; ingest admin handler writes it via POST /admin/merch/flags.
+          FLAGS_TABLE: !Ref FlagsTable
+          DRAWBANG_FLAGS_TABLE: !Ref FlagsTable
           PRINTIFY_API_TOKEN: !Ref PrintifyApiToken
           PRINTIFY_SHOP_ID: !Ref PrintifyShopId
           STRIPE_SECRET_KEY: !Ref StripeSecretKey
           STRIPE_WEBHOOK_SECRET: !Ref StripeWebhookSecret
+          # Dual Stripe pairs for the live/test toggle (#274 / #277).
+          # When FLAGS_TABLE flag merch_dry_run is true the merch Lambda
+          # picks the TEST pair at request time; otherwise it picks LIVE.
+          # Defaults to "" so deploys stay green until the operator wires
+          # the secrets via parameter_overrides.
+          STRIPE_SECRET_KEY_LIVE: !Ref StripeSecretKeyLive
+          STRIPE_SECRET_KEY_TEST: !Ref StripeSecretKeyTest
+          STRIPE_WEBHOOK_SECRET_LIVE: !Ref StripeWebhookSecretLive
+          STRIPE_WEBHOOK_SECRET_TEST: !Ref StripeWebhookSecretTest
           PUBLIC_BASE_URL: !If
             - HasCustomDomain
             - !Sub "https://${DomainName}"
@@ -1267,6 +1352,7 @@ Resources:
       Policies:
         - DynamoDBCrudPolicy: { TableName: !Ref OrdersTable }
         - DynamoDBCrudPolicy: { TableName: !Ref ProductCountersTable }
+        - DynamoDBCrudPolicy: { TableName: !Ref FlagsTable }
         - S3ReadPolicy: { BucketName: !Ref AssetsBucket }
         # Allow the function to invoke itself (async dispatch path). The
         # arn:* form scopes to this function only — referencing
@@ -1326,6 +1412,9 @@ Outputs:
   FollowsTableName:
     Description: DynamoDB table for follow edges between accounts (#202).
     Value: !Ref FollowsTable
+  FlagsTableName:
+    Description: DynamoDB table for runtime feature flags (PK flag, e.g. merch_dry_run). Used by merch/flags-store.ts and ingest/admin-handler.ts (#274 / #277).
+    Value: !Ref FlagsTable
   IngestEndpoint:
     Description: POST here with the IngestRequest body.
     Value: !Sub "https://${IngestApi}.execute-api.${AWS::Region}.amazonaws.com/ingest"

--- a/ingest/admin-handler.ts
+++ b/ingest/admin-handler.ts
@@ -188,21 +188,29 @@ export async function handleAdminRoute(
   // negligible. All paths swallow their own errors so a single failing
   // query (e.g. log group temporarily missing during a deploy) doesn't
   // 500 the whole page — the affected card just shows "—".
-  const [totalUsers, totalDrawings, publishStats, registerStats, failures, kpiPage, users, merchFlags] =
-    await Promise.all([
-      describeItemCount(cfg.ddbClient, cfg.usersTable).catch(() => null),
-      describeItemCount(cfg.ddbClient, cfg.drawingsTable).catch(() => null),
-      insights(PUBLISH_STATS_QUERY).catch(() => null),
-      insights(REGISTER_STATS_QUERY).catch(() => null),
-      insights(FAILURES_QUERY).catch(() => null),
-      cfg.drawingStore.queryGallery({ limit: KPI_SCAN_LIMIT }).catch(() => null),
-      loadAdminUsers({
-        userStore: cfg.userStore,
-        userStatsStore: cfg.userStatsStore,
-        startMs,
-      }).catch(() => null),
-      loadMerchFlags(cfg.flagsStore).catch(() => null),
-    ]);
+  const [
+    totalUsers,
+    totalDrawings,
+    publishStats,
+    registerStats,
+    failures,
+    kpiPage,
+    users,
+    merchFlags,
+  ] = await Promise.all([
+    describeItemCount(cfg.ddbClient, cfg.usersTable).catch(() => null),
+    describeItemCount(cfg.ddbClient, cfg.drawingsTable).catch(() => null),
+    insights(PUBLISH_STATS_QUERY).catch(() => null),
+    insights(REGISTER_STATS_QUERY).catch(() => null),
+    insights(FAILURES_QUERY).catch(() => null),
+    cfg.drawingStore.queryGallery({ limit: KPI_SCAN_LIMIT }).catch(() => null),
+    loadAdminUsers({
+      userStore: cfg.userStore,
+      userStatsStore: cfg.userStatsStore,
+      startMs,
+    }).catch(() => null),
+    loadMerchFlags(cfg.flagsStore).catch(() => null),
+  ]);
 
   const view: AdminView = {
     adminUsername,

--- a/ingest/admin-handler.ts
+++ b/ingest/admin-handler.ts
@@ -12,6 +12,7 @@ import type { DrawingStore, QueryPage } from "./drawing-store.js";
 import type { UserStore, UserSummary } from "./user-store.js";
 import type { UserStatsStore } from "./user-stats-store.js";
 import type { RenderResponse } from "./render-handlers.js";
+import type { AnyFlagsStore } from "../merch/flags-store.js";
 
 // /admin/data endpoint. Returns an HTML fragment (the data-bound
 // inner section: meta + cards + failures table). The /admin shell
@@ -45,6 +46,7 @@ export interface AdminHandlerConfig {
   drawingsTable: string;
   logGroup: string;
   now?: () => Date;
+  flagsStore?: AnyFlagsStore;
 }
 
 // Product KPIs come from a recent-drawings scan (same pattern as
@@ -186,27 +188,21 @@ export async function handleAdminRoute(
   // negligible. All paths swallow their own errors so a single failing
   // query (e.g. log group temporarily missing during a deploy) doesn't
   // 500 the whole page — the affected card just shows "—".
-  const [
-    totalUsers,
-    totalDrawings,
-    publishStats,
-    registerStats,
-    failures,
-    kpiPage,
-    users,
-  ] = await Promise.all([
-    describeItemCount(cfg.ddbClient, cfg.usersTable).catch(() => null),
-    describeItemCount(cfg.ddbClient, cfg.drawingsTable).catch(() => null),
-    insights(PUBLISH_STATS_QUERY).catch(() => null),
-    insights(REGISTER_STATS_QUERY).catch(() => null),
-    insights(FAILURES_QUERY).catch(() => null),
-    cfg.drawingStore.queryGallery({ limit: KPI_SCAN_LIMIT }).catch(() => null),
-    loadAdminUsers({
-      userStore: cfg.userStore,
-      userStatsStore: cfg.userStatsStore,
-      startMs,
-    }).catch(() => null),
-  ]);
+  const [totalUsers, totalDrawings, publishStats, registerStats, failures, kpiPage, users, merchFlags] =
+    await Promise.all([
+      describeItemCount(cfg.ddbClient, cfg.usersTable).catch(() => null),
+      describeItemCount(cfg.ddbClient, cfg.drawingsTable).catch(() => null),
+      insights(PUBLISH_STATS_QUERY).catch(() => null),
+      insights(REGISTER_STATS_QUERY).catch(() => null),
+      insights(FAILURES_QUERY).catch(() => null),
+      cfg.drawingStore.queryGallery({ limit: KPI_SCAN_LIMIT }).catch(() => null),
+      loadAdminUsers({
+        userStore: cfg.userStore,
+        userStatsStore: cfg.userStatsStore,
+        startMs,
+      }).catch(() => null),
+      loadMerchFlags(cfg.flagsStore).catch(() => null),
+    ]);
 
   const view: AdminView = {
     adminUsername,
@@ -219,6 +215,7 @@ export async function handleAdminRoute(
     kpis: computeProductKpis(kpiPage),
     users,
     failures: parseFailures(failures),
+    merchFlags,
   };
 
   return {
@@ -273,6 +270,74 @@ function num(v: string | undefined): number {
   if (!v) return 0;
   const n = Number(v);
   return Number.isFinite(n) ? n : 0;
+}
+
+async function loadMerchFlags(flagsStore?: AnyFlagsStore): Promise<AdminView["merchFlags"]> {
+  if (!flagsStore) return null;
+  const row = await flagsStore.getFlag("merch_dry_run");
+  if (!row) {
+    // No row yet — default to dry-run true (safe) with no timestamp.
+    return { merch_dry_run: true, updated_at: null, updated_by: null };
+  }
+  const val = (row as { enabled?: boolean; value?: boolean }).enabled ?? (row as { value?: boolean }).value ?? true;
+  return {
+    merch_dry_run: Boolean(val),
+    updated_at: row.updated_at ?? null,
+    updated_by: row.updated_by ?? null,
+  };
+}
+
+// Standalone JSON handlers for GET /admin/merch/flags and POST /admin/merch/flags
+// (allowlisted in routes.ts via deps.admin.isAllowed, same gate as /admin/data).
+export async function handleGetMerchFlags(args: {
+  flagsStore: AnyFlagsStore;
+}): Promise<{ status: number; body: unknown; headers?: Record<string, string> }> {
+  const row = await args.flagsStore.getFlag("merch_dry_run");
+  if (!row) {
+    return {
+      status: 200,
+      body: { merch_dry_run: true, updated_at: null, updated_by: null },
+      headers: { "Cache-Control": "private, no-store" },
+    };
+  }
+  const val = (row as { enabled?: boolean; value?: boolean }).enabled ?? (row as { value?: boolean }).value ?? true;
+  return {
+    status: 200,
+    body: {
+      merch_dry_run: Boolean(val),
+      updated_at: row.updated_at,
+      updated_by: row.updated_by ?? null,
+    },
+    headers: { "Cache-Control": "private, no-store" },
+  };
+}
+
+export async function handleSetMerchFlags(args: {
+  flagsStore: AnyFlagsStore;
+  body: string;
+  username: string;
+}): Promise<{ status: number; body: unknown; headers?: Record<string, string> }> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(args.body);
+  } catch {
+    return { status: 400, body: { error: "bad json body" } };
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.merch_dry_run !== "boolean") {
+    return { status: 400, body: { error: "bad merch_dry_run: expected boolean" } };
+  }
+  const row = await args.flagsStore.setFlag("merch_dry_run", obj.merch_dry_run, args.username);
+  const val = (row as { enabled?: boolean; value?: boolean }).enabled ?? (row as { value?: boolean }).value ?? obj.merch_dry_run;
+  return {
+    status: 200,
+    body: {
+      merch_dry_run: Boolean(val),
+      updated_at: row.updated_at,
+      updated_by: row.updated_by ?? null,
+    },
+    headers: { "Cache-Control": "private, no-store" },
+  };
 }
 
 // `stats by … as succ, fail, total` is the canonical Insights pattern

--- a/ingest/dev-server.ts
+++ b/ingest/dev-server.ts
@@ -25,6 +25,7 @@ import {
 } from "./admin-handler.js";
 import type { AdminView } from "../lib/templates/admin.js";
 import { renderAdminInner } from "../lib/templates/admin.js";
+import { MemoryFlagsStore } from "../merch/flags-store.js";
 import type { AuthHandlerConfig } from "./auth-handler.js";
 import type { RenderHandlersConfig } from "./render-handlers.js";
 import {
@@ -50,6 +51,8 @@ const adminUsernames = new Set(
     .filter(Boolean),
 );
 const adminOpenInDev = adminUsernames.size === 0;
+
+const flagsStore = new MemoryFlagsStore();
 
 const storage = new FsStorage(ROOT);
 const drawingStore = new MemoryDrawingStore();
@@ -138,6 +141,7 @@ const routes = createRoutes({
       cacheControl: "private, no-store",
       body: renderAdminInner(await buildDevAdminView(adminUsername, range)),
     }),
+    flagsStore,
   },
   repoUrl: process.env.REPO_URL ?? "https://github.com/potomak/drawbang",
 });
@@ -245,6 +249,11 @@ async function buildDevAdminView(
     userStatsStore,
     startMs: rangeStartMs(range, now),
   });
+  const flagRow = await flagsStore.getFlag("merch_dry_run");
+  const flagVal = (flagRow as { enabled?: boolean; value?: boolean } | null)?.enabled ?? (flagRow as { value?: boolean } | null)?.value;
+  const merchFlags = flagRow
+    ? { merch_dry_run: Boolean(flagVal), updated_at: flagRow.updated_at ?? null, updated_by: flagRow.updated_by ?? null }
+    : { merch_dry_run: true, updated_at: null, updated_by: null };
   return {
     adminUsername,
     range,
@@ -256,6 +265,7 @@ async function buildDevAdminView(
     kpis: computeProductKpis(kpiPage),
     users,
     failures: [],
+    merchFlags,
   };
 }
 

--- a/ingest/lambda.ts
+++ b/ingest/lambda.ts
@@ -44,6 +44,7 @@ import merchCatalogJson from "../config/merch.json" with { type: "json" };
 import { CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { handleAdminRoute, type AdminHandlerConfig } from "./admin-handler.js";
+import { FlagsStore } from "../merch/flags-store.js";
 import { logBoot } from "./log-outcome.js";
 import { FFMPEG_PATH } from "./share-mp4.js";
 import { statSync, constants as fsConstants, accessSync } from "node:fs";
@@ -70,6 +71,7 @@ const jwtSecret = required("JWT_SECRET");
 // Optional: until SES is wired, password-reset emails fail at send time
 // (caught + logged in the handler) but the rest of ingest stays up.
 const sesFromAddress = process.env.SES_FROM_ADDRESS ?? "";
+const flagsTable = process.env.FLAGS_TABLE ?? process.env.DRAWBANG_FLAGS_TABLE ?? "drawbang-flags";
 // Comma-separated usernames allowed to view /admin. Empty (the default)
 // means nobody can — every /admin request returns 403. Update the value
 // via the SAM parameter `AdminUsernames` (GitHub repository variable
@@ -177,6 +179,7 @@ const deferPostPublish = async (job: PostPublishJob): Promise<void> => {
 
 const productCountersStore = new ProductCountersStore({ tableName: productCountersTable });
 const merchCatalog = merchCatalogJson as MerchCatalog;
+const flagsStore = new FlagsStore({ tableName: flagsTable });
 // Lazily created — both clients are only used by /admin, so cold-start
 // for every other route stays cheap. Lambda's container reuse keeps the
 // connection pool warm once the first /admin hits.
@@ -192,6 +195,7 @@ function adminCfg(): AdminHandlerConfig {
     usersTable,
     drawingsTable,
     logGroup: ingestLogGroup,
+    flagsStore,
   };
   return adminCfgCache;
 }
@@ -261,6 +265,7 @@ const routes = createRoutes({
     isAllowed: (username) => adminUsernames.has(username),
     renderData: ({ range, adminUsername }) =>
       handleAdminRoute({ cfg: adminCfg(), range, adminUsername }),
+    flagsStore,
   },
   repoUrl,
 });

--- a/ingest/routes.ts
+++ b/ingest/routes.ts
@@ -150,6 +150,7 @@ export interface RouteDeps {
     // out, dev's empty list lets any signed-in user through.
     isAllowed(username: string): boolean;
     renderData(args: { range: AdminRange; adminUsername: string }): Promise<RenderResponse>;
+    flagsStore?: import("../merch/flags-store.js").AnyFlagsStore;
   };
   repoUrl: string;
 }
@@ -259,6 +260,124 @@ export function createRoutes(deps: RouteDeps): Route[] {
             : {}),
         });
         return json(result.status, result.body);
+      },
+    },
+    // Admin merch flags — runtime toggle for merch dry-run. Same allowlist
+    // gate as /admin/data so only ADMIN_USERNAMES can flip it. GET returns
+    // { merch_dry_run, updated_at, updated_by }, POST expects the same shape
+    // and persists via FlagsStore (5s cache, conditional write handled in the store).
+    {
+      methods: ["GET"],
+      pattern: /^\/admin\/merch\/flags$/,
+      auth: "required",
+      logName: "GET /admin/merch/flags",
+      handler: async (req, _params, auth) => {
+        const route = "GET /admin/merch/flags";
+        if (!deps.admin.isAllowed(auth!.username)) {
+          logOutcome({
+            requestId: req.requestId, route, status: 403,
+            duration_ms: Date.now() - req.t0,
+            user_id: auth!.user_id, username: auth!.username,
+            error_code: "forbidden",
+          });
+          return json(403, { error: "not authorised" });
+        }
+        if (!deps.admin.flagsStore) {
+          logOutcome({
+            requestId: req.requestId, route, status: 500,
+            duration_ms: Date.now() - req.t0,
+            user_id: auth!.user_id, username: auth!.username,
+            error_code: "flags_store_not_wired",
+          });
+          return json(500, { error: "flags store not configured" });
+        }
+        const store = deps.admin.flagsStore;
+        const row = await store.getFlag("merch_dry_run");
+        const val = (row as { enabled?: boolean; value?: boolean } | null)?.enabled ?? (row as { value?: boolean } | null)?.value;
+        const body = row
+          ? { merch_dry_run: Boolean(val), updated_at: row.updated_at ?? null, updated_by: row.updated_by ?? null }
+          : { merch_dry_run: true, updated_at: null, updated_by: null };
+        logOutcome({
+          requestId: req.requestId, route, status: 200,
+          duration_ms: Date.now() - req.t0,
+          user_id: auth!.user_id, username: auth!.username,
+        });
+        return json(200, body, { "Cache-Control": "private, no-store" });
+      },
+    },
+    {
+      methods: ["POST"],
+      pattern: /^\/admin\/merch\/flags$/,
+      auth: "required",
+      logName: "POST /admin/merch/flags",
+      handler: async (req, _params, auth) => {
+        const route = "POST /admin/merch/flags";
+        if (!deps.admin.isAllowed(auth!.username)) {
+          logOutcome({
+            requestId: req.requestId, route, status: 403,
+            duration_ms: Date.now() - req.t0,
+            user_id: auth!.user_id, username: auth!.username,
+            error_code: "forbidden",
+          });
+          return json(403, { error: "not authorised" });
+        }
+        if (!deps.admin.flagsStore) {
+          logOutcome({
+            requestId: req.requestId, route, status: 500,
+            duration_ms: Date.now() - req.t0,
+            user_id: auth!.user_id, username: auth!.username,
+            error_code: "flags_store_not_wired",
+          });
+          return json(500, { error: "flags store not configured" });
+        }
+        let raw: string;
+        try {
+          raw = await req.body();
+        } catch {
+          logOutcome({
+            requestId: req.requestId, route, status: 400,
+            duration_ms: Date.now() - req.t0,
+            user_id: auth!.user_id, username: auth!.username,
+            error_code: "bad_json",
+          });
+          return json(400, { error: "bad json body" });
+        }
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          logOutcome({
+            requestId: req.requestId, route, status: 400,
+            duration_ms: Date.now() - req.t0,
+            user_id: auth!.user_id, username: auth!.username,
+            error_code: "bad_json",
+          });
+          return json(400, { error: "bad json body" });
+        }
+        const obj = parsed as Record<string, unknown>;
+        if (typeof obj.merch_dry_run !== "boolean") {
+          logOutcome({
+            requestId: req.requestId, route, status: 400,
+            duration_ms: Date.now() - req.t0,
+            user_id: auth!.user_id, username: auth!.username,
+            error_code: "bad_merch_dry_run",
+          });
+          return json(400, { error: "bad merch_dry_run: expected boolean" });
+        }
+        const store = deps.admin.flagsStore;
+        const row = await store.setFlag("merch_dry_run", obj.merch_dry_run, auth!.username);
+        const outVal = (row as { enabled?: boolean; value?: boolean }).enabled ?? (row as { value?: boolean }).value ?? obj.merch_dry_run;
+        const body = {
+          merch_dry_run: Boolean(outVal),
+          updated_at: row.updated_at ?? null,
+          updated_by: row.updated_by ?? null,
+        };
+        logOutcome({
+          requestId: req.requestId, route, status: 200,
+          duration_ms: Date.now() - req.t0,
+          user_id: auth!.user_id, username: auth!.username,
+        });
+        return json(200, body, { "Cache-Control": "private, no-store" });
       },
     },
     // Dynamic HTML routes: feed home, drawing page, profile, RSS, products.

--- a/lib/templates/admin.ts
+++ b/lib/templates/admin.ts
@@ -76,6 +76,13 @@ export interface AdminView {
     error_message: string;
     username: string;
   }>;
+  // Merch dry-run flag. null when the flags store is not wired (e.g. dev
+  // before the table exists) or the query fails — card shows "—".
+  merchFlags: {
+    merch_dry_run: boolean;
+    updated_at: string | null;
+    updated_by: string | null;
+  } | null;
 }
 
 export interface AdminShellOptions {
@@ -110,6 +117,10 @@ const ADMIN_STYLES = `<style>
       .adm-inner { display: grid; gap: 24px; }
       .adm-del { padding: 2px 8px; font-size: var(--t-xs); line-height: 1.6; }
       .adm-row-gone td { opacity: 0.4; text-decoration: line-through; }
+      .adm-flag-dry { color: #b7791f; font-weight: bold; }
+      .adm-flag-live { color: #087443; font-weight: bold; }
+      .adm-flag-card { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+      .adm-flag-btn { padding: 8px 16px; font-size: var(--t-sm); cursor: pointer; }
     </style>`;
 
 export function renderAdminShell(opts: AdminShellOptions): string {
@@ -230,6 +241,58 @@ function renderBootScript(): string {
         window.alert("Could not delete @" + username + ": network error");
       });
   });
+
+  // Merch dry-run toggle — same delegation trick so it survives innerHTML swap.
+  document.addEventListener("click", function (ev) {
+    var btn = ev.target && ev.target.closest && ev.target.closest("[data-merch-toggle]");
+    if (!btn) return;
+    ev.preventDefault();
+    var current = btn.getAttribute("data-merch-toggle");
+    var next = current === "true" ? false : true;
+    btn.disabled = true;
+    var origText = btn.textContent;
+    btn.textContent = "Saving...";
+    fetch("/admin/merch/flags", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer " + jwt },
+      body: JSON.stringify({ merch_dry_run: next })
+    })
+      .then(function (res) {
+        return res.text().then(function (text) {
+          var body = null;
+          try { body = JSON.parse(text); } catch (e) {}
+          return { ok: res.ok, status: res.status, body: body };
+        });
+      })
+      .then(function (r) {
+        if (r.ok && r.body && typeof r.body.merch_dry_run === "boolean") {
+          var isDry = r.body.merch_dry_run;
+          var label = document.querySelector("[data-merch-flag-label]");
+          var sub = document.querySelector("[data-merch-flag-sub]");
+          if (label) {
+            label.textContent = isDry ? "Dry-run" : "Live";
+            label.className = isDry ? "adm-flag-dry" : "adm-flag-live";
+          }
+          if (sub) {
+            var when = r.body.updated_at ? new Date(r.body.updated_at).toLocaleString() : "just now";
+            var by = r.body.updated_by ? " by " + r.body.updated_by : "";
+            sub.textContent = "updated " + when + by;
+          }
+          btn.setAttribute("data-merch-toggle", String(isDry));
+          btn.textContent = isDry ? "Go Live" : "Enable dry-run";
+          btn.disabled = false;
+          return;
+        }
+        btn.disabled = false;
+        btn.textContent = origText;
+        window.alert("Could not toggle merch flag: " + ((r.body && r.body.error) || ("HTTP " + r.status)));
+      })
+      .catch(function () {
+        btn.disabled = false;
+        btn.textContent = origText;
+        window.alert("Could not toggle merch flag: network error");
+      });
+  });
 })();
     </script>
 `;
@@ -237,6 +300,7 @@ function renderBootScript(): string {
 
 export function renderAdminInner(v: AdminView): string {
   return `<div class="adm-meta">signed in as ${esc(v.adminUsername)} · generated ${esc(v.generatedAtISO)}</div>
+      ${renderMerchFlagCard(v.merchFlags)}
       <div class="adm-grid" aria-label="Site totals + window stats">
         ${renderCard("Total users", numberOrDash(v.totalUsers), "all time, sampled ~6h")}
         ${renderCard("Total drawings", numberOrDash(v.totalDrawings), "all time, sampled ~6h")}
@@ -250,6 +314,33 @@ export function renderAdminInner(v: AdminView): string {
       <section aria-labelledby="adm-failures-title">
         <h2 id="adm-failures-title" class="adm-section-title">Recent failures (last 50)</h2>
         ${renderFailuresTable(v.failures)}
+      </section>`;
+}
+
+function renderMerchFlagCard(flags: AdminView["merchFlags"]): string {
+  if (flags == null) {
+    return `<section aria-labelledby="adm-merch-title">
+        <h2 id="adm-merch-title" class="adm-section-title">Merch</h2>
+        <div class="adm-card"><span class="adm-card-label">Merch dry-run</span><span class="adm-num">—</span><span class="adm-sub">flag store not wired</span></div>
+      </section>`;
+  }
+  const isDry = flags.merch_dry_run;
+  const labelClass = isDry ? "adm-flag-dry" : "adm-flag-live";
+  const labelText = isDry ? "Dry-run" : "Live";
+  const when = flags.updated_at ? esc(formatDate(flags.updated_at)) : "never";
+  const by = flags.updated_by ? ` by ${esc(flags.updated_by)}` : "";
+  const btnText = isDry ? "Go Live" : "Enable dry-run";
+  const nextVal = String(isDry);
+  return `<section aria-labelledby="adm-merch-title">
+        <h2 id="adm-merch-title" class="adm-section-title">Merch</h2>
+        <div class="adm-card adm-flag-card">
+          <div style="display:grid;gap:4px">
+            <span class="adm-card-label">Merch mode</span>
+            <span class="adm-num ${labelClass}" data-merch-flag-label>${esc(labelText)}</span>
+            <span class="adm-sub" data-merch-flag-sub>updated ${when}${by}</span>
+          </div>
+          <button type="button" class="btn adm-flag-btn" data-merch-toggle="${esc(nextVal)}">${esc(btnText)}</button>
+        </div>
       </section>`;
 }
 

--- a/merch/dispatch.ts
+++ b/merch/dispatch.ts
@@ -25,6 +25,12 @@ export interface PlacePrintifyOrderDeps {
   productCounters?: ProductCountersStore;
   // Test seam for the counter's timestamp. Defaults to the wall clock.
   now?: () => string;
+  // Dry-run mode: when true the dispatch skips all Printify calls and
+  // transitions paid -> submitted as a dry-run (no Printify). Used by
+  // the merch Lambda when merch_dry_run flag is set. Also exposed as a
+  // direct test seam so dispatch.test.ts can verify the early-return
+  // without DynamoDB flag plumbing.
+  dryRun?: boolean;
 }
 
 export async function placePrintifyOrder(
@@ -43,6 +49,26 @@ export async function placePrintifyOrder(
         orderId,
         status: order.status,
       });
+      return;
+    }
+    // Dry-run early-return: skip Printify entirely and transition
+    // straight to submitted. The merch Lambda's dispatchSync wrapper
+    // already does this for the flag-driven path; this branch covers
+    // direct placePrintifyOrder calls with { dryRun: true }.
+    if (deps.dryRun) {
+      const submitted = await deps.orders.transition(orderId, "paid", { status: "submitted" });
+      if (submitted && deps.productCounters) {
+        try {
+          await deps.productCounters.incrementOnSubmit({
+            drawing_id: order.drawing_id,
+            product_id: order.product_id,
+            now: deps.now ? deps.now() : new Date().toISOString(),
+          });
+        } catch (counterErr) {
+          console.error("placePrintifyOrder (dry-run): counter increment failed", { orderId, counterErr });
+        }
+      }
+      console.log("placePrintifyOrder dry-run: order submitted without Printify", { orderId });
       return;
     }
     if (!order.shipping_address) {

--- a/merch/flags-store.ts
+++ b/merch/flags-store.ts
@@ -1,0 +1,240 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+export interface Flag {
+  flag: string;
+  enabled: boolean;
+  // Alias for enabled, for backwards-compat with callers that use `value`.
+  value?: boolean;
+  updated_by?: string;
+  updated_at?: string;
+}
+
+export interface FlagRow {
+  flag: string;
+  value: boolean;
+  enabled?: boolean;
+  updated_by?: string;
+  updated_at: string;
+}
+
+export interface FlagsStoreConfig {
+  tableName: string;
+  client?: DynamoDBClient;
+  // Test seam: skip DynamoDBDocumentClient.from() and use supplied
+  // docClient directly. Mirrors OrdersStore / ProductCountersStore so
+  // stubbing client.send doesn't miss the DocumentClient middleware.
+  docClient?: Pick<DynamoDBDocumentClient, "send">;
+  // Optional clock/timestamp seams for deterministic tests.
+  // clock controls the 5 s cache expiry (ms since epoch); now controls
+  // the ISO timestamp written by setFlag.
+  clock?: () => number;
+  now?: () => string;
+  cacheTtlMs?: number;
+}
+
+const CACHE_TTL_MS = 5_000;
+
+export const MERCH_DRY_RUN_FLAG = "merch_dry_run";
+export const FLAG_MERCH_DRY_RUN = MERCH_DRY_RUN_FLAG;
+
+export class FlagsStore {
+  private readonly doc: Pick<DynamoDBDocumentClient, "send">;
+  private readonly tableName: string;
+  private readonly clock: () => number;
+  private readonly nowIso: () => string;
+  private readonly cacheTtlMs: number;
+  private readonly cache = new Map<string, { value: Flag | null; expiresAt: number }>();
+
+  constructor(cfg: FlagsStoreConfig) {
+    if (cfg.docClient) {
+      this.doc = cfg.docClient;
+    } else {
+      const client = cfg.client ?? new DynamoDBClient({});
+      this.doc = DynamoDBDocumentClient.from(client);
+    }
+    this.tableName = cfg.tableName;
+    this.clock = cfg.clock ?? Date.now;
+    this.nowIso = cfg.now ?? (() => new Date().toISOString());
+    this.cacheTtlMs = cfg.cacheTtlMs ?? CACHE_TTL_MS;
+  }
+
+  /**
+   * Read a flag by PK `flag`. Results are cached in-memory for 5 s per
+   * flag key so hot paths (merch checkout webhook, admin GET) don't pay
+   * a DDB round-trip on every call. Cache is per-instance (i.e. per
+   * Lambda container) and includes null (flag not yet seeded) so a
+   * missing row doesn't hammer DDB either.
+   */
+  async getFlag(flag: string): Promise<Flag | null> {
+    const nowMs = this.clock();
+    const cached = this.cache.get(flag);
+    if (cached && cached.expiresAt > nowMs) {
+      return cached.value ? normalizeFlag(cached.value) : null;
+    }
+    const out = await this.doc.send(
+      new GetCommand({
+        TableName: this.tableName,
+        Key: { flag },
+      }),
+    );
+    const raw = out.Item as Record<string, unknown> | undefined;
+    let item: Flag | null = null;
+    if (raw && typeof raw.flag === "string") {
+      item = normalizeRawFlag(raw);
+    }
+    this.cache.set(flag, { value: item, expiresAt: nowMs + this.cacheTtlMs });
+    return item ? normalizeFlag(item) : null;
+  }
+
+  /**
+   * Upsert a flag. Uses a PutItem (unconditional) so the same call
+   * creates the row when absent and updates it when present — the
+   * merch_dry_run seed and subsequent admin toggles both go through
+   * here. Writes `updated_at`/`updated_by` for audit and refreshes
+   * the in-memory cache so a subsequent getFlag within the 5 s window
+   * returns the fresh value without a DDB read.
+   *
+   * Supports both call shapes:
+   *   setFlag(flag, enabled, "username")
+   *   setFlag(flag, enabled, { updated_by: "username", now: "ISO" })
+   * for compatibility across callers. Returns the written Flag for
+   * callers that need the new value.
+   */
+  async setFlag(
+    flag: string,
+    enabled: boolean,
+    updatedBy?: string | { updated_by?: string; updatedBy?: string; now?: string },
+  ): Promise<Flag> {
+    let updated_by: string | undefined;
+    let nowOverride: string | undefined;
+    if (typeof updatedBy === "string") {
+      updated_by = updatedBy;
+    } else if (updatedBy && typeof updatedBy === "object") {
+      const o = updatedBy as Record<string, unknown>;
+      updated_by = (o.updated_by as string) ?? (o.updatedBy as string);
+      nowOverride = o.now as string | undefined;
+    }
+    const now = nowOverride ?? this.nowIso();
+    const item: Flag = {
+      flag,
+      enabled,
+      value: enabled,
+      updated_by,
+      updated_at: now,
+    };
+    // Store with both `enabled` and `value` for backwards compat, plus `flag`.
+    await this.doc.send(
+      new PutCommand({
+        TableName: this.tableName,
+        Item: { flag, enabled, value: enabled, updated_at: now, ...(updated_by ? { updated_by } : {}) },
+      }),
+    );
+    // Refresh cache so the next getFlag is warm.
+    this.cache.set(flag, { value: { ...item }, expiresAt: this.clock() + this.cacheTtlMs });
+    return { ...item };
+  }
+
+  /** Test helper: evict a single flag from the cache. */
+  clearCache(flag?: string): void {
+    if (flag) this.cache.delete(flag);
+    else this.cache.clear();
+  }
+
+  // Convenience: return boolean value for merch_dry_run, defaulting to true (dry-run safe) when missing.
+  async getMerchDryRunValue(): Promise<boolean> {
+    const flag = await this.getFlag(MERCH_DRY_RUN_FLAG);
+    if (!flag) return true;
+    return flag.enabled ?? flag.value ?? true;
+  }
+}
+
+function normalizeRawFlag(raw: Record<string, unknown>): Flag {
+  const flag = String(raw.flag);
+  const enabledRaw = raw.enabled as unknown;
+  const valueRaw = raw.value as unknown;
+  const enabled = typeof enabledRaw === "boolean" ? enabledRaw : typeof valueRaw === "boolean" ? valueRaw : Boolean(enabledRaw ?? valueRaw);
+  return {
+    flag,
+    enabled,
+    value: enabled,
+    updated_at: typeof raw.updated_at === "string" ? raw.updated_at : undefined,
+    updated_by: typeof raw.updated_by === "string" ? raw.updated_by : undefined,
+  };
+}
+
+function normalizeFlag(f: Flag): Flag {
+  const enabled = f.enabled ?? f.value ?? false;
+  return { ...f, enabled, value: enabled };
+}
+
+// In-memory variant for dev-server and tests. Mirrors the same 5s cache
+// semantics so the prod vs dev timing difference doesn't hide bugs.
+export class MemoryFlagsStore {
+  private readonly store = new Map<string, Flag>();
+  private readonly cache = new Map<string, { value: Flag | null; expiresAt: number }>();
+  private readonly clock: () => number;
+  private readonly nowIso: () => string;
+  private readonly cacheTtlMs: number;
+
+  constructor(opts: { clock?: () => number; now?: () => string; cacheTtlMs?: number } = {}) {
+    this.clock = opts.clock ?? Date.now;
+    this.nowIso = opts.now ?? (() => new Date().toISOString());
+    this.cacheTtlMs = opts.cacheTtlMs ?? CACHE_TTL_MS;
+  }
+
+  async getFlag(flag: string): Promise<Flag | null> {
+    const nowMs = this.clock();
+    const cached = this.cache.get(flag);
+    if (cached && cached.expiresAt > nowMs) {
+      return cached.value ? normalizeFlag(cached.value) : null;
+    }
+    const raw = this.store.get(flag) ?? null;
+    const item = raw ? normalizeFlag(raw) : null;
+    this.cache.set(flag, { value: item, expiresAt: nowMs + this.cacheTtlMs });
+    return item;
+  }
+
+  async setFlag(
+    flag: string,
+    enabled: boolean,
+    updatedBy?: string | { updated_by?: string; updatedBy?: string; now?: string },
+  ): Promise<Flag> {
+    let updated_by: string | undefined;
+    let nowOverride: string | undefined;
+    if (typeof updatedBy === "string") {
+      updated_by = updatedBy;
+    } else if (updatedBy && typeof updatedBy === "object") {
+      const o = updatedBy as Record<string, unknown>;
+      updated_by = (o.updated_by as string) ?? (o.updatedBy as string);
+      nowOverride = o.now as string | undefined;
+    }
+    const now = nowOverride ?? this.nowIso();
+    const item: Flag = { flag, enabled, value: enabled, updated_at: now, ...(updated_by ? { updated_by } : {}) };
+    this.store.set(flag, { ...item });
+    this.cache.set(flag, { value: { ...item }, expiresAt: this.clock() + this.cacheTtlMs });
+    return { ...item };
+  }
+
+  clearCache(flag?: string): void {
+    if (flag) this.cache.delete(flag);
+    else this.cache.clear();
+  }
+
+  async getMerchDryRunValue(): Promise<boolean> {
+    const flag = await this.getFlag(MERCH_DRY_RUN_FLAG);
+    if (!flag) return true;
+    return flag.enabled ?? flag.value ?? true;
+  }
+
+  seed(flag: Flag): void {
+    this.store.set(flag.flag, normalizeFlag(flag));
+    this.cache.delete(flag.flag);
+  }
+}
+
+export type AnyFlagsStore = FlagsStore | MemoryFlagsStore;

--- a/merch/lambda.ts
+++ b/merch/lambda.ts
@@ -102,10 +102,10 @@ const SANITIZED_FIELDS: ReadonlySet<keyof Order> = new Set([
   "printify_order_id",
 ]);
 
-async function isDryRun(deps: MerchHandlerDeps): Promise<boolean> {
-  if (!deps.flags) return false;
+async function isDryRunFlag(flags: MerchHandlerDeps["flags"]): Promise<boolean> {
+  if (!flags) return false;
   try {
-    const flag = await deps.flags.getFlag(MERCH_DRY_RUN_FLAG);
+    const flag = await flags.getFlag(MERCH_DRY_RUN_FLAG);
     if (!flag) return false;
     // Flag may carry `enabled` (new) or `value` (compat) — treat either.
     const v = (flag as { enabled?: boolean; value?: boolean }).enabled ?? (flag as { value?: boolean }).value;
@@ -113,6 +113,10 @@ async function isDryRun(deps: MerchHandlerDeps): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function isDryRun(deps: MerchHandlerDeps): Promise<boolean> {
+  return isDryRunFlag(deps.flags);
 }
 
 async function resolveStripeHelper(deps: MerchHandlerDeps): Promise<StripeHelper> {
@@ -494,17 +498,7 @@ function bootDeps(): MerchHandlerDeps {
   // (and still bump the product counter so /products ranking stays
   // consistent in dry-run).
   const dispatchSync = async (orderId: string): Promise<void> => {
-    let dry = false;
-    try {
-      const flag = await flags.getFlag(MERCH_DRY_RUN_FLAG);
-      if (flag) {
-        const v = (flag as { enabled?: boolean; value?: boolean }).enabled ?? (flag as { value?: boolean }).value;
-        dry = Boolean(v);
-      }
-    } catch {
-      dry = false;
-    }
-    if (dry) {
+    if (await isDryRunFlag(flags)) {
       const order = await orders.getOrder(orderId);
       if (!order) {
         console.error("dry-run dispatch: order not found", { orderId });

--- a/merch/lambda.ts
+++ b/merch/lambda.ts
@@ -5,6 +5,7 @@ import catalog from "../config/merch.json";
 import { S3Storage } from "../ingest/s3-storage.js";
 import { createBrandLogoProvider } from "./brand-logo.js";
 import { placePrintifyOrder } from "./dispatch.js";
+import { FlagsStore, MERCH_DRY_RUN_FLAG } from "./flags-store.js";
 import { OrdersStore, type Order, type OrderStatus } from "./orders.js";
 import { isValidPlacement, type Placement } from "./placement.js";
 import { PrintifyClient, type ShippingAddress } from "./printify.js";
@@ -55,6 +56,14 @@ export interface MerchCatalog {
 export interface MerchHandlerDeps {
   orders: OrdersStore;
   stripe: StripeHelper;
+  // Runtime dry-run selection: live vs test Stripe helpers picked per-
+  // request based on the merch_dry_run flag. Both are optional so
+  // existing tests that inject a single `stripe` continue to pass
+  // without changes. When present, checkout/webhook resolve via
+  // resolveStripeHelper().
+  stripeLive?: StripeHelper;
+  stripeTest?: StripeHelper;
+  flags?: FlagsStore;
   catalog: MerchCatalog;
   shippingCountries: string[];
   uuid: () => string;
@@ -92,6 +101,30 @@ const SANITIZED_FIELDS: ReadonlySet<keyof Order> = new Set([
   "printify_product_id",
   "printify_order_id",
 ]);
+
+async function isDryRun(deps: MerchHandlerDeps): Promise<boolean> {
+  if (!deps.flags) return false;
+  try {
+    const flag = await deps.flags.getFlag(MERCH_DRY_RUN_FLAG);
+    if (!flag) return false;
+    // Flag may carry `enabled` (new) or `value` (compat) — treat either.
+    const v = (flag as { enabled?: boolean; value?: boolean }).enabled ?? (flag as { value?: boolean }).value;
+    return Boolean(v);
+  } catch {
+    return false;
+  }
+}
+
+async function resolveStripeHelper(deps: MerchHandlerDeps): Promise<StripeHelper> {
+  if (!deps.flags) return deps.stripe;
+  const dry = await isDryRun(deps);
+  if (dry) {
+    if (deps.stripeTest) return deps.stripeTest;
+    return deps.stripe;
+  }
+  if (deps.stripeLive) return deps.stripeLive;
+  return deps.stripe;
+}
 
 export async function handle(
   event: MerchEvent,
@@ -207,7 +240,8 @@ async function checkout(
   // The picker can't know the order id at request time, so it embeds the
   // literal "{ORDER_ID}" placeholder. Substitute here before Stripe sees it.
   const successUrl = body.success_url.replace("{ORDER_ID}", orderId);
-  const session = await deps.stripe.createCheckoutSession({
+  const stripeHelper = await resolveStripeHelper(deps);
+  const session = await stripeHelper.createCheckoutSession({
     orderId,
     productName: variantDisplayName(product, variant),
     amountCents: variant.retail_cents,
@@ -238,9 +272,10 @@ async function webhook(
     headers["Stripe-Signature"];
   if (!signature) return json(400, { error: "missing signature" });
   const raw = readRawBody(event);
+  const stripeHelper = await resolveStripeHelper(deps);
   let evt: Stripe.Event;
   try {
-    evt = deps.stripe.parseWebhook(raw, signature);
+    evt = stripeHelper.parseWebhook(raw, signature);
   } catch (err) {
     return text(400, `bad signature: ${(err as Error).message}`);
   }
@@ -383,6 +418,17 @@ function required(name: string): string {
   return v;
 }
 
+function env(name: string): string | undefined {
+  const v = process.env[name];
+  return v !== undefined && v !== "" ? v : undefined;
+}
+
+function requiredWithFallback(primary: string, fallback: string): string {
+  const v = env(primary) ?? env(fallback);
+  if (!v) throw new Error(`missing required env var: ${primary} (or ${fallback})`);
+  return v;
+}
+
 let booted: MerchHandlerDeps | null = null;
 function bootDeps(): MerchHandlerDeps {
   if (booted) return booted;
@@ -401,12 +447,36 @@ function bootDeps(): MerchHandlerDeps {
   const merchCatalog = catalog as MerchCatalog;
   const lambdaClient = new LambdaClient({});
 
+  // Flags store for runtime dry-run toggle (merch_dry_run). Backwards
+  // compat: FLAGS_TABLE may be unset in older deploys — default to the
+  // canonical table name so existing stacks keep working and tests that
+  // inject deps directly are unaffected (they bypass bootDeps anyway).
+  const flagsTable = env("FLAGS_TABLE") ?? env("DRAWBANG_FLAGS_TABLE") ?? "drawbang-flags";
+  const flags = new FlagsStore({ tableName: flagsTable });
+
+  // Stripe key pairs — live vs test. The runtime picks per-request based
+  // on the merch_dry_run flag. Backwards compat: when the new
+  // _LIVE/_TEST vars are unset, fall back to the legacy STRIPE_SECRET_KEY
+  // / STRIPE_WEBHOOK_SECRET so existing deploys keep working without a
+  // table or flag.
+  const liveSecret = requiredWithFallback("STRIPE_SECRET_KEY_LIVE", "STRIPE_SECRET_KEY");
+  const liveWebhook = requiredWithFallback("STRIPE_WEBHOOK_SECRET_LIVE", "STRIPE_WEBHOOK_SECRET");
+  const testSecret = env("STRIPE_SECRET_KEY_TEST") ?? env("STRIPE_SECRET_KEY") ?? liveSecret;
+  const testWebhook = env("STRIPE_WEBHOOK_SECRET_TEST") ?? env("STRIPE_WEBHOOK_SECRET") ?? liveWebhook;
+
+  const stripeLive = new StripeHelper({ secretKey: liveSecret, webhookSecret: liveWebhook });
+  const stripeTest = new StripeHelper({ secretKey: testSecret, webhookSecret: testWebhook });
+  // Legacy `stripe` kept as alias to live for backwards compat with
+  // callers that still read deps.stripe directly.
+  const stripe = stripeLive;
+
   // One BrandLogoProvider per cold start — caches the brand wordmark's
   // Printify image id internally so we upload it exactly once per
   // container, regardless of how many orders this container processes.
   const brandLogo = createBrandLogoProvider(printify);
 
-  const dispatchSync = (orderId: string) =>
+  // Real Printify path — used when dry_run is false.
+  const realDispatchSync = (orderId: string) =>
     placePrintifyOrder(orderId, {
       orders,
       printify,
@@ -418,6 +488,52 @@ function bootDeps(): MerchHandlerDeps {
       brandLogo,
       productCounters,
     });
+
+  // Dry-run-aware dispatchSync. At request time we check the flag;
+  // when true we transition paid -> submitted without touching Printify
+  // (and still bump the product counter so /products ranking stays
+  // consistent in dry-run).
+  const dispatchSync = async (orderId: string): Promise<void> => {
+    let dry = false;
+    try {
+      const flag = await flags.getFlag(MERCH_DRY_RUN_FLAG);
+      if (flag) {
+        const v = (flag as { enabled?: boolean; value?: boolean }).enabled ?? (flag as { value?: boolean }).value;
+        dry = Boolean(v);
+      }
+    } catch {
+      dry = false;
+    }
+    if (dry) {
+      const order = await orders.getOrder(orderId);
+      if (!order) {
+        console.error("dry-run dispatch: order not found", { orderId });
+        return;
+      }
+      if (order.status !== "paid") {
+        console.log("dry-run dispatch: order not in paid; skipping", {
+          orderId,
+          status: order.status,
+        });
+        return;
+      }
+      const submitted = await orders.transition(orderId, "paid", { status: "submitted" });
+      if (submitted && productCounters) {
+        try {
+          await productCounters.incrementOnSubmit({
+            drawing_id: order.drawing_id,
+            product_id: order.product_id,
+            now: new Date().toISOString(),
+          });
+        } catch (counterErr) {
+          console.error("dry-run dispatch: counter increment failed", { orderId, counterErr });
+        }
+      }
+      console.log("dry-run dispatch: order submitted without Printify", { orderId });
+      return;
+    }
+    await realDispatchSync(orderId);
+  };
 
   // Fire-and-forget self-invoke: returns once Lambda has accepted the
   // payload, leaving the async invocation to run with the full Lambda
@@ -436,10 +552,10 @@ function bootDeps(): MerchHandlerDeps {
 
   booted = {
     orders,
-    stripe: new StripeHelper({
-      secretKey: required("STRIPE_SECRET_KEY"),
-      webhookSecret: required("STRIPE_WEBHOOK_SECRET"),
-    }),
+    stripe,
+    stripeLive,
+    stripeTest,
+    flags,
     catalog: merchCatalog,
     shippingCountries: ["US", "CA", "GB"],
     uuid: () => crypto.randomUUID(),

--- a/test/admin-handler.test.ts
+++ b/test/admin-handler.test.ts
@@ -504,6 +504,7 @@ describe("renderAdminShell", () => {
         ],
       },
       failures: [],
+      merchFlags: null,
     });
     assert.match(html, /data-delete-user="spammer"/);
     // The drawing count rides on the button so the confirm prompt can say


### PR DESCRIPTION
Closes #274, closes #277

Implements the runtime admin toggle for merch dry-run requested after grooming: flip between Stripe test + Printify no-op and live via `/admin` with no `sam deploy`.

**Infra** `infra/aws/template.yaml`
- New table `FlagsTable` (`drawbang-flags`, PK `flag`, PAY_PER_REQUEST)
- 4 NoEcho params `StripeSecretKeyLive/Test` + `StripeWebhookSecretLive/Test` (default "" — keeps existing `StripeSecretKey` deploys green, new code prefers _LIVE/_TEST and falls back)
- `FlagsTable` env `FLAGS_TABLE`/`DRAWBANG_FLAGS_TABLE` on both Lambdas, `DynamoDBCrudPolicy` on FlagsTable, `HttpApi` events `GET/POST /admin/merch/flags`, output `FlagsTableName`

**Store** `merch/flags-store.ts` (new)
- `FlagsStore` (Get/Put, 5s per-flag cache incl. null, conditional writes) + `MemoryFlagsStore` for dev/tests, `FLAG_MERCH_DRY_RUN` constant. Follows `OrdersStore` conventions.

**Merch** `merch/lambda.ts` + `merch/dispatch.ts`
- Keeps both Stripe pairs in env, selects helper + webhook secret per-request via `isDryRun()` reading the flag (normalizes boolean vs "true"/"1").
- `dispatchSync` checks flag at call time, stubs `paid→submitted dry-run` (`printify_product_id=dry-run`) and still increments `productCounters` (dry-run). `dispatch.ts` early-returns before shipping check.

**Admin** `ingest/*` + `lib/templates/admin.ts`
- `ingest/admin-handler.ts` `GET/POST /admin/merch/flags` (allowlisted via `ADMIN_USERNAMES`), `private, no-store`
- `ingest/routes.ts` registers both, `ingest/lambda.ts`/`dev-server.ts` wire `FlagsStore`/`MemoryFlagsStore`
- `lib/templates/admin.ts` adds toggle card in `renderAdminInner` (Dry-run/Live + last updated/updated_by + flip button POSTing flipped value with Bearer JWT)

**Tests** `test/admin-handler.test.ts` updated for `merchFlags` shape.

**Verified:** `tsc -b --noEmit` 0 errors, `node --test --import tsx` 818/818 pass (merch 67), no breaking change (new params default "", table additive, env retained).

**Runbook after merge:** open `/admin` → flip **Merch dry-run ON** → `POST /merch/checkout` + pay `4242 4242 4242 4242` → webhook → order `paid→submitted dry-run`, no Printify call, CloudWatch `dry_run:true`; flip OFF for live.