### PR TITLE
ci(deploy): wire STRIPE_SECRET_KEY_TEST / STRIPE_WEBHOOK_SECRET_TEST

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,8 @@ jobs:
           PRINTIFY_SHOP_ID: ${{ secrets.PRINTIFY_SHOP_ID }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          STRIPE_SECRET_KEY_TEST: ${{ secrets.STRIPE_SECRET_KEY_TEST }}
+          STRIPE_WEBHOOK_SECRET_TEST: ${{ secrets.STRIPE_WEBHOOK_SECRET_TEST }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           # Not sensitive (a public From address) — a prod environment variable,
           # not a secret. secrets.* would resolve empty and skip the param.
@@ -117,6 +119,8 @@ jobs:
             "PrintifyShopId=${PRINTIFY_SHOP_ID}" \
             "StripeSecretKey=${STRIPE_SECRET_KEY}" \
             "StripeWebhookSecret=${STRIPE_WEBHOOK_SECRET}" \
+            "StripeSecretKeyTest=${STRIPE_SECRET_KEY_TEST}" \
+            "StripeWebhookSecretTest=${STRIPE_WEBHOOK_SECRET_TEST}" \
             "JwtSecret=${JWT_SECRET}" \
             "SesFromAddress=${SES_FROM_ADDRESS}" \
             "AdminUsernames=${ADMIN_USERNAMES}" \


### PR DESCRIPTION
Follow-up to #285 (merch dry-run toggle). The merch Lambda now keeps both LIVE and TEST Stripe pairs and picks at request time via the FlagsTable, but `deploy.yml` was still only passing the legacy `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` to `sam deploy`.

This adds the TEST pair to the deploy env + `parameter_overrides` loop, sourced from repo secrets `STRIPE_SECRET_KEY_TEST` / `STRIPE_WEBHOOK_SECRET_TEST` (set via `gh secret set` with the `sk_test_…` / `whsec_…` you just provided). When empty the params are skipped and template defaults keep the stack green.

After merge, with the test secrets set, dry-run ON in `/admin` will actually use `sk_test` (so `4242` works with no charge).

Stripe test webhook for this stack: `https://0blf98navf.execute-api.us-east-1.amazonaws.com/merch/webhook/stripe` (raw MerchEndpoint + `/webhook/stripe`, **not** `/pixel.drawbang.com`) — create it in **Test mode** with **Events on: Your account**, events `checkout.session.completed` + `payment_intent.payment_failed`.

Merge and the next deploy will carry both pairs.