### PR TITLE
ci: run test (incl. format:check) on pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: deploy
 on:
   push:
     branches: [master]
+  pull_request:
+    branches: [master]
   schedule:
     - cron: "0 6 * * *" # daily gallery rebuild
   workflow_dispatch:


### PR DESCRIPTION
The `format:check` gate added in #286 lives in the `test` job of `deploy.yml`, but that workflow only ran on `push: master` / `schedule` / `workflow_dispatch` — so PRs never executed it and you didn't see the check.

This adds `pull_request: branches: [master]` to `on:`. The `test` job will now run on every PR (typecheck → format:check → test), while `deploy-lambda` and `build-and-publish` keep their `if: push` guards so they still only deploy on master pushes.

After merge, every PR will show the `test` check (including `format:check`) in the PR checks list.