### PR TITLE
fix(merch): default merch_dry_run to true when flag missing — prevents live Printify when admin says dry-run

### DIFF
--- a/merch/lambda.ts
+++ b/merch/lambda.ts
@@ -101,17 +101,21 @@ const SANITIZED_FIELDS: ReadonlySet<keyof Order> = new Set([
 ]);
 
 async function isDryRunFlag(flags: MerchHandlerDeps["flags"]): Promise<boolean> {
-  if (!flags) return false;
+  if (!flags) return true;
   try {
     const flag = await flags.getFlag(MERCH_DRY_RUN_FLAG);
-    if (!flag) return false;
+    if (!flag) return true;
     // Flag may carry `enabled` (new) or `value` (compat) — treat either.
+    // Missing flag defaults to dry-run true (safe) — matches
+    // FlagsStore.getMerchDryRunValue and ingest/admin-handler loadMerchFlags.
     const v =
       (flag as { enabled?: boolean; value?: boolean }).enabled ??
       (flag as { value?: boolean }).value;
-    return Boolean(v);
+    // If the row exists but carries no boolean, stay safe.
+    if (typeof v !== "boolean") return true;
+    return v;
   } catch {
-    return false;
+    return true;
   }
 }
 


### PR DESCRIPTION
Hotfix for live dispatch when admin shows Dry-run.

**Root cause:** `merch/lambda.ts:isDryRunFlag` returned `false` (live) when the flag row was absent or a read failed, while `ingest/admin-handler.ts:loadMerchFlags` and `FlagsStore.getMerchDryRunValue` both defaulted to `true` (dry-run). A fresh `drawbang-flags` table therefore showed **Dry-run** in `/admin` but `resolveStripeHelper` picked `sk_live` and `dispatchSync` called the real Printify path.

**Fix:** Make `isDryRunFlag` safe-by-default — missing store, missing row, missing boolean, or read error all return `true`. Now missing/unreadable flag = dry-run, matching admin and store semantics. Once the operator explicitly sets `merch_dry_run=false` via `/admin/merch/flags`, live mode is used.

**Immediate mitigation for the live shirt:**
1. `curl -X POST https://pixel.drawbang.com/admin/merch/flags -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" -d '{"merch_dry_run":true}'` (or toggle in /admin — should now stay Dry-run)
2. Cancel in Printify Dashboard → Orders → find `external_id=<order_id>` → Cancel (if still On Hold). If already In Production, open Printify support — reference external_id.
3. Refund in Stripe Dashboard (Test vs Live — check which key was used: if checkout url was `/c/test_` it was test, else live needs refund).

**Test plan:**
- `npm run format:check` — prettier pass
- `npm run typecheck` — pass
- `npm test` — 818/818 (merch 67)
- Manual: with no flag row, checkout now uses `sk_test` and webhook lands `submitted` with `printify_product_id=dry-run`

Fixes reports of live Printify order while admin said dry-run.