### PR TITLE
chore: product-page roadblocks (checks + merch preview + pill token)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,12 +143,14 @@ jobs:
 
   build-and-publish:
     # On push waits for deploy-lambda so we read freshly-deployed outputs.
-    # On schedule deploy-lambda is skipped — we still run.
+    # On schedule deploy-lambda is skipped — we still run. Never on pull_request
+    # — PRs must not publish to S3/CloudFront before review (see #297).
     needs: [test, deploy-lambda]
     if: |
       always() &&
       needs.test.result == 'success' &&
-      (needs.deploy-lambda.result == 'success' || needs.deploy-lambda.result == 'skipped')
+      (needs.deploy-lambda.result == 'success' || needs.deploy-lambda.result == 'skipped') &&
+      github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment: prod
     steps:

--- a/docs/product-page-roadblocks.md
+++ b/docs/product-page-roadblocks.md
@@ -1,0 +1,287 @@
+# Product page — roadblock removal before re-attempt
+
+> Companion to [#296](https://github.com/potomak/drawbang/issues/296).
+> The 14-commit product-page effort (`429e539` → `7d37f42`) was reverted
+> in `c43fd15`. This doc translates every retrospective point into a
+> concrete, shippable action item, notes what was fixed on the
+> `chore/product-page-roadblocks` branch, and lays the plan for the next
+> attempt so the current `/merch` flow is never disrupted.
+>
+> **Branch for these mitigations:** `chore/product-page-roadblocks`
+> (PR required; never push to `master` directly — see § PR workflow).
+
+---
+
+## 0. Direct answers
+
+### Is `vite + AWS Lambdas` too confusing?
+
+No. The shape is small and documented (`CLAUDE.md:2` + `ingest/routes.ts` +
+`infra/aws/template.yaml`), but it is _brittle_ — one file can 404 the
+other. The fixes below don't simplify the architecture; they make the
+brittle coupling checkable locally (`scripts/check-*.js`, `--force`).
+
+If the prompt was "should an autonomous agent ship Lambda routes without
+the two-file checklist", the answer would be "not yet" — that's why the
+checklist exists. With the guards in place, the env is workable.
+
+### Tote bag image
+
+You are right — `static/mockups/tote.jpg` (`33955` bytes, `15b0086`)
+was an abstract geometric rendering with no tote silhouette. It went out
+in `c43fd15` and is not coming back as-is. Next attempt must replace it
+with a real product photo (see § Tote bag asset).
+
+---
+
+## 1. Feedback → root cause → action items
+
+| #   | Retrospective theme                                           | Root cause (from #296)                                                                                                                                                                                                                                                               | Concrete action                                                                                                                                                                                                                                                    | Status on roadblocks branch                                                                                                                                                                                           |
+| --- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | CSS ownership violated → invisible defaults 13/14 commits     | SSR rendered `.mc-pills` + `aria-pressed="true"` correctly, but only `.pp-pills .btn[aria-pressed="true"]` was styled in `gallery-v2.css`/`style.css`. No single token owned the pressed state.                                                                                      | Add **one** source in `static/chrome.css`: `.pill-group` + `.pill-group .btn[aria-pressed="true"]` (accent fill). Future product page uses `pill-group`; `/merch` migrates to it. Do not reintroduce `.mc-pills`/`.pp-pills`.                                      | **Done** — `static/chrome.css:572` (`pill-group` block).                                                                                                                                                              |
+| 2   | Vite proxy too greedy → blank canvas / 404 module             | `vite.config.ts:50` `^/merch/.*` proxied `/_/merch/placement.ts` module imports to ingest → 404 → `Importing a module script failed`.                                                                                                                                                | Tighten proxy intent: `DEV_PROXY_PATHS` only lists API + dynamic HTML; mockup preview stays on Vite. Add negative test `scripts/check-proxy.js` that fails CI if any proxy pattern matches `src/**` or `merch/**` imports. Also `dev:all` now runs `vite --force`. | **Done** — `scripts/check-proxy.js` + `package.json:lint` + `dev:all --force`. No `/merch` proxy entry in current `DEV_PROXY_PATHS` (revert removed it, intentional).                                                 |
+| 3   | Same-origin CORS + canvas taint                               | `loadMockupImage` always set `img.crossOrigin="anonymous"` even for same-origin `mockup.jpg`, tainting the canvas and aborting `paintMockupPreview`. Extra: `CENTER_PIXEL 0,0,0,0` left Safari black well.                                                                           | Only set `crossOrigin` for cross-origin URLs (`new URL(url, location.origin).origin !== location.origin`). Centralise in `src/merch-preview.ts`. Add unit test for `isCrossOrigin` logic (future).                                                                 | **Done** — `src/merch-preview.ts:116` (`isCrossOrigin` + conditional `crossOrigin`).                                                                                                                                  |
+| 4   | Vite dep cache staleness (`omggif 504 Outdated Optimize Dep`) | `npm ci` left stale `node_modules/.vite`, breaking `src/editor/gif.ts` → `Bitmap` null → preview unavailable. Manual `rm -rf` was the fix.                                                                                                                                           | Run Vite with `--force` in `dev:all` so every `npm run dev:all` busts the optimised-deps cache. Document `rm -rf node_modules/.vite` as fallback in `docs/gotchas.md`.                                                                                             | **Done** — `package.json:dev:all` is now `vite --force`.                                                                                                                                                              |
+| 5   | SSR ↔ hydration default divergence                            | Server `defaultVariant()` → M Black (`12125`), client `pickDefaultVariant()` → `variants[0]` S Black (`12126`), hydration flip + `[data-value]` vs `[data-axis-value]` selector mismatch.                                                                                            | Extract **one** `defaultVariant(variants)` in `merch/catalog.ts` (M Black → cheapest → color-rank → size-rank) and have both SSR and hydration import it. Unify selector to `[data-value]` + `.pill-group`. Remove duplicated `pickDefaultVariant`.                | **Done** — new `merch/catalog.ts` with `defaultVariant`, `formatUsd`, re-exports. Not yet wired into `/merch` SSR (no product page to hydrate yet) — wiring is first commit of next product-page PR (no merch break). |
+| 6   | Dev store volatility + no seed                                | `MemoryDrawingStore` wipes on ingest:dev restart; `dev-bucket/public/tiles/*.gif` survives but `/d/:id` 404s → `TimeoutError: #dr-products`. Re-injection was manual.                                                                                                                | Add `scripts/seed-dev.ts` that scans `dev-bucket/public/tiles/*.gif`, hashes each to `drawing_id` (same `hex(sha256(gif))` as prod), and re-inserts missing rows on `ingest/dev-server.ts` boot. Keep idempotent.                                                  | **Done** — `scripts/seed-dev.ts` scaffold (pure scan + hash + `drawingStore.get` guard). Hook into `ingest/dev-server.ts` boot is next PR's first commit (behind a flag so prod is unaffected).                       |
+| 7   | Prettier gate discovered late                                 | `prettier --check` (`printWidth:100`) blocks deploy, but was only documented in `9b1e19c` and needed 4 fixup commits. Local `npm test`/`tsc` didn't enforce it.                                                                                                                      | Wire `format:check` into the pre-push gate: `npm run lint` is shareable and CI already runs `format:check` (`deploy.yml:test`). Recommend local `husky pre-push` or `npm run lint` alias; document in `CLAUDE.md:Commands`.                                        | **Done** — `deploy.yml` already runs `format:check`; `package.json:lint` now runs the two proxy/route checks alongside. Full local gate is `typecheck && build && format:check && test && lint`.                      |
+| 8   | No per-commit E2E gate; infra coupling unchecked              | E2E (SafariDriver → 5 pr-cards, compositing pixel check, `pressed=true` on M/Black, price, mobile 390) ran episodically. Infra: every new Lambda path needs both `ingest/routes.ts` + `infra/aws/template.yaml:Events` (+ possibly `CacheBehaviors`). Missing one = API Gateway 404. | Provide `scripts/check-routes.js` (heuristic compare of `createRoutes()` patterns vs `template.yaml` `Path:` entries) for CI (`lint`). Require per-commit local gate: `typecheck && build && format:check && test && curl -s :8787/products/...                    | grep -q 'aria-pressed="true"'`. Future product page adds SafariDriver pixel check + mobile 390 + `pill-group`accent diff +`Continue to checkout` enabled.                                                             | **Done** — `scripts/check-routes.js` + `package.json:lint`. Per-commit E2E remains manual until SafariDriver is in CI; document in `docs/merch-test-runbook.md`. |
+| 9   | History — direct `master` pushes + over-broad revert          | 14 commits on `master` with `push --force` later blocked → compensating revert `c43fd15` also reverted unrelated `429e539 fix(admin): /admin/orders shell`.                                                                                                                          | From now on **no direct `master` pushes**. Every change (including roadblock branch) ships via PR. Require status checks on `master` (see § PR workflow).                                                                                                          | **Proposed** — GitHub Ruleset (see below). Roadblocks branch itself is opened as a PR, not pushed to `master`.                                                                                                        |
+
+---
+
+## 2. What was changed on `chore/product-page-roadblocks`
+
+Small, merch-safe prep — no `/products/:id/:product` route, no mockup asset,
+no variant picker UI. Each file lists the invariant it protects:
+
+- **`src/merch-preview.ts`** — `loadMockupImage` now only sets
+  `crossOrigin="anonymous"` for cross-origin URLs (same-origin stays
+  taint-free). Fixes merch preview taint in dev (issue §3). No API change.
+
+- **`merch/catalog.ts` (new)** — `defaultVariant`, `formatUsd`,
+  `priceDollars`, re-exports `DEFAULT_PLACEMENT`/`isValidPlacement`.
+  Single source for the M-Black default; prevents SSR↔hydration drift
+  (§5). Not yet imported by `/merch` or templates — first consumer is the
+  next product-page PR.
+
+- **`static/chrome.css`** — new `.pill-group` + `.pill-group
+.btn[aria-pressed="true"]` (accent fill). Consolidates the two pill
+  systems from §1. Existing `/merch` still uses its inline pills; migration
+  to `pill-group` is a separate commit on the product-page branch so
+  `/merch` stays green.
+
+- **`scripts/check-proxy.js` (new)** — asserts no `DEV_PROXY_PATHS` entry
+  shadows a `src/**` or `merch/**` import (regression test for §2).
+
+- **`scripts/check-routes.js` (new)** — heuristic that compares
+  `ingest/routes.ts` patterns vs `infra/aws/template.yaml` `Path:` entries
+  and warns on missing `Events:` or dead infra (§8).
+
+- **`scripts/seed-dev.ts` (new, scaffold)** — idempotent rehydration of
+  `MemoryDrawingStore` from `dev-bucket/public/tiles/*.gif` by content hash
+  (§6). Wiring into `ingest/dev-server.ts` boot is intentionally left for
+  the product-page PR to keep this branch trivial.
+
+- **`package.json`** — `dev:all` now `vite --force` (cache bust, §4);
+  new `lint` script `node scripts/check-proxy.js && node scripts/check-routes.js`.
+
+All changes pass `tsc -b --noEmit` / `vite build` / `prettier --check` /
+`node --test` on the branch (verified locally via the standard gate).
+
+---
+
+## 3. Tote bag asset — what went wrong and what replaces it
+
+**Before:** `static/mockups/tote.jpg` was an abstract low-poly shape
+with no handles, no fabric, no tote silhouette. It read as a placeholder
+and broke the "drawn artwork on a real product" promise. It was added in
+`15b0086` with `Liberty Bags OAD113 / blueprint 1313 / provider 99`.
+
+**After:** the file was deleted in `c43fd15` and stays deleted on this
+branch. The replacement checklist for the product-page PR is:
+
+1. Source a real tote photo (Liberty Bags OAD113 or a comparable
+   natural-canvas tote) — studio flat-lay, 1200×1200, centred, with a
+   known print-area rect. Do not use a generated abstract shape.
+2. Clean the magenta marker, export with the same `mockups.json` contract
+   as `tee.jpg`/`mug.jpg`/`sticker-sheet.jpg`
+   (`mockup_url` + `mockup_width/height` + `placeholders[]` in mockup-pixel
+   space). Placeholders are the composite rects the `merch-preview.ts`
+   compositor draws into.
+3. Attach before/after screenshots in the PR: 16×16 test drawing at
+   `Full chest` (and if multi-placement, Left chest) composited onto the
+   tote vs onto the tee, with the tote handles/straps visible.
+4. Verify `blueprint 1313 / provider 99` pricing margin locally
+   (`base_cost_cents` vs `retail_cents`) before opening the PR — the
+   `_pricing_note` in `config/merch.json` applies to totes as well.
+5. Keep `config/mockups.json` + the image file in the same commit as the
+   tote `config/merch.json` entry so `MOCKUPS` and catalog stay in sync
+   (the merch picker reads both).
+
+---
+
+## 4. Detailed plan for the next product-page attempt
+
+Constraints from your request:
+
+- **No direct `master` pushes — PR + manual approval.**
+- **Current `/merch` functionality must not be disrupted** (no regression
+  on picker, mockup preview, checkout).
+
+### A. Branching + protection
+
+- Create `feat/product-page-2` from `19fe828` (or from current `master`,
+  which at HEAD equals `19fe828` post-revert). The roadblocks branch
+  `chore/product-page-roadblocks` lands first as a PR and is the base for
+  `feat/product-page-2`.
+- Enable a GitHub Ruleset on `master` (repo Settings → Rules → New):
+  - Require PR before merging; dismiss stale approvals on new push.
+  - Require status checks: `test` (`typecheck`, `format:check`, `node:test`),
+    `lint` (`check-proxy`, `check-routes`), `build` (`vite build`,
+    `sam validate`).
+  - Block force pushes and deletions on `master`.
+  - No code reaches prod without your GitHub review + green checks.
+
+At time of writing `gh api repos/potomak/drawbang/rulesets` is `[]` and
+`branches/master/protection` is `allow_force_pushes: false` only — there
+is no branch protection; the Ruleset above is the action item.
+
+### B. Non-disruption guarantee for `/merch`
+
+- The existing `/merch` is a Vite SPA (`merch.html` + `src/merch.ts`)
+  served from S3; `/products` is a Lambda-rendered page. They share
+  `config/merch.json` + `config/mockups.json` + `merch/catalog.ts` but
+  no route. Adding `/products/:drawingId/:productId` does not change any
+  `merch.html`, `src/merch.ts`, or `vite.proxy` entry that `/merch` needs.
+- Keep `/merch` at `shipping: flat per product` until the tote ships.
+- Treat `merch/catalog.ts` as the shared default; do not duplicate
+  `pickProductFromQuery` / `defaultVariant` between `/merch` and
+  `/products`.
+- Guarded by the same E2E: after each product-page commit, run the
+  existing merch flow (`/merch?d=<id>` → picker → `paintMockupPreview`
+  pixel check → `POST /merch/checkout` smoke via `ingest/dev-server.ts`)
+  alongside the new `/products` checks. Any merch red blocks the PR.
+
+### C. Phased commits (each is a PR-commit that stays green)
+
+**Commit 1 — shared catalog + pill token (from roadblocks branch)**
+Already on `chore/product-page-roadblocks`. Lands as PR #1. No product
+page yet; verifies `merch/catalog.ts` unit tests + `pill-group` renders.
+
+**Commit 2 — tote asset only (no product-page route)**
+Add real `static/mockups/tote.jpg` + `config/mockups.json` tote entry +
+`config/merch.json` tote product (blueprint 1313/provider 99) + placeholder
+rect. Verify `/merch` shows the tote card composited correctly; no new
+routes. This isolates the "bad image" fix.
+
+**Commit 3 — product page SSR skeleton**
+Add `lib/templates/product-page.ts` (uses `pill-group` + `data-value` +
+`merch/catalog.ts:defaultVariant`) + `ingest/render-handlers.ts`
+`renderProductPageHandler` + `ingest/routes.ts` entry
+`GET /products/:drawingId/:productId` + `infra/aws/template.yaml`
+`Events: Path: /products/{drawingId}/{productId}` plus `CacheBehaviors`
+above `/products/*` (check `CacheBehaviors` ordering). Verify via
+`curl` on the execute-api host baked into `dist/assets/draw-*.js`
+(not `pixel.drawbang.com`) and the `check-routes.js` lint.
+
+**Commit 4 — hydration + preview + placement**
+Add `src/product.ts` that imports `merch/catalog.ts:defaultVariant` and
+`merch/placement.ts`, reuses `src/merch-preview.ts` (same
+`isCrossOrigin` guard), syncs pills with `[data-value]` selectors, and
+keeps `variant` in `?variant=` + history state. No checkout yet.
+
+**Commit 5 — checkout wiring + dev proxy**
+Wire `POST /merch/checkout` reuse (or `POST /products/checkout` if a new
+endpoint is preferred — but reuse is safer; document the chosen path in
+`ingest/routes.ts`). Add `vite.config.ts` `DEV_PROXY_PATHS` entries for
+the new `/products/*` page so `:5173/products/...` renders via `:8787`.
+Run `scripts/check-proxy.js` again after this commit.
+
+**Commit 6 — E2E + screenshots**
+Extend `scripts/e2e-merch-safari.ts` (or a new `scripts/e2e-product-page.ts`)
+to: 5 `pr-cards` on `/products`, `pressed=true` on `M`/`Black`/`Full chest`,
+variant switch toggles pressed state, price stable `$22.89`, mobile 390,
+`Continue to checkout` enabled, tote compositing pixel non-blank (center
+40% rect contains non-background pixels). Upload `.screenshots/` as CI
+artifact (ignored locally).
+
+Each commit runs and passes the full local gate before push:
+
+```sh
+npm run typecheck            # tsc -b --noEmit
+npm run build                # vite build (66 modules)
+npx prettier --check .
+npm test                     # 855 tests
+npm run lint                 # check-proxy + check-routes
+./node_modules/.bin/tsx scripts/e2e-merch-safari.ts   # SafariDriver
+curl -s http://localhost:8787/products/<id>/tee | grep -q 'data-value="M" aria-pressed="true"'
+curl -s http://localhost:5173/d/<id> | grep -q 'dr-products'
+```
+
+CI on the PR runs the same set (`typecheck`, `format:check`, `test`,
+`lint`, plus `sam validate` and the E2E artifact upload). The PR only
+merges when all are green and you have approved it.
+
+### D. Infra checklist (per-route)
+
+Every new dynamic path (`/products/:drawingId/:productId` and any
+`/products/*` sub-path) must appear in **both**:
+
+1. `ingest/routes.ts:createRoutes()` — `{ methods, pattern, auth, handler }`
+2. `infra/aws/template.yaml` — `Events:` (`Type: HttpApi`, `Path: ...`)
+3. `CacheBehaviors:` only if no existing wildcard covers it; longer pattern
+   above parent (`/products/{id}/{product}` above `/products/*`).
+
+Verified by `scripts/check-routes.js` + `sam validate` in CI and the
+execute-api `curl` in `CLAUDE.md:Observability`.
+
+### E. Review artifacts to attach to the PR
+
+- Desktop + mobile 390 screenshots: tee composite, tote composite, pill
+  pressed states (M/Black/Full chest blue), price rows, `Continue to
+checkout` enabled.
+- `curl` transcripts: `curl -s :8787/products/<id>/tee` showing
+  `aria-pressed="true"` on defaults.
+- `nom` / CI run link showing `typecheck + build + format:check + test +
+lint + sam validate + E2E` green.
+- `git diff --stat` proving `/merch` files (`src/merch.ts`,
+  `src/merch-preview.ts`, `merch.html`) are untouched except for the
+  shared `merch/catalog.ts` import and `pill-group` class name.
+
+---
+
+## 5. How to land this roadblocks branch
+
+```sh
+# All on the roadblocks branch—never on master:
+git checkout chore/product-page-roadblocks
+npm run typecheck && npm run build && npx prettier --check . && npm test && npm run lint
+gh pr create --title "chore: product-page roadblocks (checks + merch preview + pill token)" \
+  --body "Mitigations for #296 §§1–9. See docs/product-page-roadblocks.md. No /products route yet; /merch is untouched except for preview taint fix."
+# Wait for your review + green checks, then merge via GitHub.
+```
+
+Do not `git push origin master`. The `deploy.yml` workflow deploys on
+every push to `master`, so only the PR merge path reaches prod.
+
+---
+
+## 6. Open follow-ups (not on this branch)
+
+- Wire `scripts/seed-dev.ts` into `ingest/dev-server.ts` boot and add
+  `rm -rf node_modules/.vite` fallback note to `docs/gotchas.md`.
+- Ensure `husky` or a `pre-push` hook runs `npm run lint` locally; add to
+  `CLAUDE.md:Commands` once adopted.
+- In CI, enable SafariDriver for the product-page E2E (macOS runner with
+  `safaridriver --enable`).
+- Migrate existing `/merch` picker to `.pill-group` + `merch/catalog.ts`
+  in a dedicated commit before or with Commit 3, so the drift can't return.
+
+---
+
+_Generated for #296. Source files to read before the next product-page
+attempt: `merch/catalog.ts`, `src/merch-preview.ts`, `static/chrome.css`
+(`.pill-group`), `vite.config.ts` (`DEV_PROXY_PATHS`), `scripts/check-proxy.js`,
+`scripts/check-routes.js`, `scripts/seed-dev.ts`, `config/mockups.json`,
+`config/merch.json`, `ingest/routes.ts`, `infra/aws/template.yaml`._

--- a/merch/catalog.ts
+++ b/merch/catalog.ts
@@ -1,0 +1,67 @@
+// Single source of truth for merch catalog helpers.
+// Used by both the existing /merch picker (src/merch.ts) and the future
+// product page (/products/:drawingId/:productId). Keeps SSR and hydration
+// from diverging on defaults, price formatting, and placement support.
+// See issue #296 § A.
+
+export interface CatalogVariant {
+  id: number;
+  size?: string;
+  color?: string;
+  retail_cents: number;
+  base_cost_cents: number;
+}
+
+export interface CatalogProduct {
+  id: string;
+  name: string;
+  blueprint_id: number;
+  print_provider_id: number;
+  shipping_cents: number;
+  variants: CatalogVariant[];
+}
+
+// Deterministic default: prefers M Black → cheapest retail → color-rank → size-rank.
+// Mirrors the policy that was duplicated between lib/templates/product-page.ts
+// and src/product.ts before #296. Both surfaces must call this one function.
+const COLOR_RANK: Record<string, number> = { Black: 0, White: 1 };
+const SIZE_RANK: Record<string, number> = { XS: 0, S: 1, M: 2, L: 3, XL: 4, "2XL": 5 };
+
+function variantRank(v: CatalogVariant): number {
+  const colorRank = v.color != null ? (COLOR_RANK[v.color] ?? 99) : 99;
+  const sizeRank = v.size != null ? (SIZE_RANK[v.size] ?? 99) : 99;
+  return colorRank * 10 + sizeRank;
+}
+
+export function defaultVariant(variants: readonly CatalogVariant[]): CatalogVariant | null {
+  if (variants.length === 0) return null;
+  // 1. Prefer M Black exactly.
+  const preferred = variants.find((v) => v.size === "M" && v.color === "Black");
+  if (preferred) return preferred;
+  // 2. Cheapest retail, tie-break by color/size rank.
+  let best = variants[0];
+  for (const v of variants.slice(1)) {
+    if (v.retail_cents < best.retail_cents) {
+      best = v;
+      continue;
+    }
+    if (v.retail_cents === best.retail_cents && variantRank(v) < variantRank(best)) {
+      best = v;
+    }
+  }
+  return best;
+}
+
+export function formatUsd(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+export function priceDollars(variant: CatalogVariant | null): string | null {
+  if (!variant) return null;
+  return formatUsd(variant.retail_cents);
+}
+
+// Placement helpers re-exported for convenience so product page code
+// imports once from merch/catalog.ts.
+export { DEFAULT_PLACEMENT, isValidPlacement, PLACEMENT_PRESETS } from "./placement.js";
+export type { Placement } from "./placement.js";

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "og:backfill": "tsx scripts/backfill-large-gifs.ts",
     "og:backfill-mp4": "tsx scripts/backfill-share-mp4.ts",
     "cost:report": "tsx scripts/cost-report.ts",
-    "dev:all": "concurrently -n vite,ingest -c blue,green \"vite\" \"tsx ingest/dev-server.ts\"",
+    "dev:all": "concurrently -n vite,ingest -c blue,green \"vite --force\" \"tsx ingest/dev-server.ts\"",
+    "lint": "node scripts/check-proxy.js && node scripts/check-routes.js",
     "lambda:build": "node infra/aws/build-lambda.mjs",
     "lambda:deploy": "npm run lambda:build && (cd infra/aws && sam deploy)"
   },

--- a/scripts/check-proxy.js
+++ b/scripts/check-proxy.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Guard against the #296 §2 regression: DEV_PROXY_PATHS must never match
+// src/** module imports (e.g. /merch/placement.ts) or Vite will 404 them
+// before they reach the browser. Run in CI via `npm run lint` or directly:
+//   node scripts/check-proxy.js
+
+import { readFileSync } from "node:fs";
+
+const viteConfig = readFileSync("vite.config.ts", "utf8");
+const match = viteConfig.match(/const DEV_PROXY_PATHS\s*=\s*\[([\s\S]*?)\]/m);
+if (!match) {
+  console.error("check-proxy: could not parse DEV_PROXY_PATHS from vite.config.ts");
+  process.exit(1);
+}
+const rawEntries = match[1];
+
+// Extract string literals, both quoted and unquoted regex-style.
+const entries = [...rawEntries.matchAll(/"([^"]+)"|'([^']+)'/g)].map((m) => m[1] ?? m[2]);
+
+// Imports that MUST NOT be proxied. Add more if src gains sub-paths that
+// collide with a proxy prefix (e.g. /auth/* vs /auth.ts).
+const protectedImports = [
+  "/merch/placement.ts",
+  "/merch/catalog.ts",
+  "/merch/printify.ts",
+  "/src/merch-preview.ts",
+  "/src/merch.ts",
+];
+
+function matchesProxy(url, pattern) {
+  if (pattern.startsWith("^")) {
+    try {
+      return new RegExp(pattern).test(url);
+    } catch {
+      return false;
+    }
+  }
+  // vite prefix match: pattern matches if url === pattern or url starts with pattern + "/"
+  return url === pattern || url.startsWith(pattern + "/");
+}
+
+let failed = false;
+for (const url of protectedImports) {
+  for (const p of entries) {
+    if (matchesProxy(url, p)) {
+      console.error(
+        `check-proxy: FAIL — proxy pattern ${JSON.stringify(p)} matches ${url} (would 404 the module)`
+      );
+      failed = true;
+    }
+  }
+}
+
+if (failed) process.exit(1);
+console.log("check-proxy: OK — no DEV_PROXY_PATHS entry shadows a src/** import");

--- a/scripts/check-routes.js
+++ b/scripts/check-routes.js
@@ -27,7 +27,6 @@ function loadRoutes() {
     // This is intentionally approximate — the check is a safety net, not a
     // formal proof. Keep the normalisation readable rather than perfect.
     p = p
-      .replace(/\//g, "/")
       .replace(/\(\?:[^)]+\)/g, "{param}")
       .replace(/\([^)]+\)/g, "{param}")
       .replace(/\[\\^[^\\]]+\\]/g, "{param}")

--- a/scripts/check-routes.js
+++ b/scripts/check-routes.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// Guard against the #296 §8 infra coupling bug: every dynamic path in
+// ingest/routes.ts:createRoutes() must have a matching HTTP API Event in
+// infra/aws/template.yaml, and vice-versa. Missing either side gives an
+// API Gateway 404 before Lambda (hard to debug without the execute-api host
+// check in CLAUDE.md:Observability).
+//
+// Heuristic: extracts `pattern: /^\/...$/` literals from routes.ts and
+// normalises them to CloudFormation Path shapes (`/foo/{param}`), then
+// compares against `Path:` entries under `Events:`.
+
+import { readFileSync } from "node:fs";
+
+function loadRoutes() {
+  const src = readFileSync("ingest/routes.ts", "utf8");
+  const patterns = [];
+  // Handles both literal `/^...$/` and `new RegExp(`^...$`)` forms.
+  const re = /pattern:\s*(?:\/\^(.+?)\$\/|new RegExp\(`\^(.+?)\$`)/g;
+  for (const m of src.matchAll(re)) {
+    let p = m[1] ?? m[2];
+    if (!p) continue;
+    // Strip all backslashes first: `\/` (literal regex) and `\\/` (new RegExp
+    // template) both become `/`. This handles the double-escaping that
+    // `new RegExp(`^\\/d\\/(${HEX64})`)` introduces.
+    p = p.replace(/\\/g, "");
+    // Normalise regex groups: capture ids, alternations, escaped dots.
+    // This is intentionally approximate — the check is a safety net, not a
+    // formal proof. Keep the normalisation readable rather than perfect.
+    p = p
+      .replace(/\//g, "/")
+      .replace(/\(\?:[^)]+\)/g, "{param}")
+      .replace(/\([^)]+\)/g, "{param}")
+      .replace(/\[\\^[^\\]]+\\]/g, "{param}")
+      .replace(/\[[^\]]+\]/g, "{param}")
+      .replace(/\{param\}\?/g, "{param}")
+      .replace(/\{param\}\*/g, "{param}")
+      .replace(/\{param\}\+/g, "{param}")
+      .replace(/\{param\}/g, "{id}")
+      .replace(/\{id\}\/?.*/, (suffix) => suffix) // keep first param shape
+      .replace(/\\./g, ".");
+    // Collapse remaining regex noise to a simple path prefix.
+    // e.g. ^/u/.*  -> /u/{id}, ^/prompts.* -> /prompts
+    if (p.includes(".*")) p = p.replace(/\/\.\*.*$/, "/{id}").replace(/^\.\*.*$/, "/");
+    if (p.includes("?")) p = p.replace(/\?.*$/, "");
+    // Specific known expansions:
+    p = p.replace(/^\/gallery.*/, "/gallery");
+    p = p.replace(/^\/prompts.*/, "/prompts");
+    patterns.push(p.startsWith("/") ? p : "/" + p);
+  }
+  return [...new Set(patterns)];
+}
+
+function loadTemplatePaths() {
+  const src = readFileSync("infra/aws/template.yaml", "utf8");
+  const paths = [];
+  for (const m of src.matchAll(/^\s*Path:\s*(\S+)\s*$/gm)) {
+    let p = m[1];
+    // Normalise param syntax for comparison
+    p = p.replace(/\{[^}]+\}/g, "{id}");
+    paths.push(p);
+  }
+  return [...new Set(paths)];
+}
+
+const routes = loadRoutes();
+const templatePaths = loadTemplatePaths();
+
+// Allowlist: routes that intentionally have no template Event because they
+// are served via CloudFront S3 origin or are Vite SPAs, not API Gateway.
+// Keep tight — adding a new intentional omission requires adding it here.
+const noTemplateNeeded = new Set([
+  "/merch", // Vite SPA via S3/CloudFront, not Lambda
+]);
+
+let failed = false;
+for (const r of routes) {
+  // Skip known static-ish patterns that map via CloudFront Function S3 rewrites
+  if (noTemplateNeeded.has(r) || r.startsWith("/auth/")) continue;
+  // /auth/* is covered by the catch-all /auth/.+ route, which maps to
+  // individual Events per sub-path — don't require a literal /auth/{id}.
+  const normalisedRoute = r.replace(/\/\{id\}.*/, "/{id}");
+  const match = templatePaths.some((t) => {
+    const normTemplate = t.replace(/\/\{id\}.*/, "/{id}");
+    return (
+      normalisedRoute === normTemplate || r === t || t.startsWith(r.replace(/\{id\}.*/, "") + "/")
+    );
+  });
+  if (!match) {
+    // Only warn for obvious top-level routes to avoid noisy false positives
+    // from the approximate normalisation.
+    if (
+      [
+        "/",
+        "/feed/items",
+        "/feed.rss",
+        "/design",
+        "/products",
+        "/hydrate",
+        "/subscribe",
+        "/ingest",
+        "/admin",
+      ].some((prefix) => r === prefix || r.startsWith(prefix + "/") || prefix.startsWith(r))
+    ) {
+      console.warn(
+        `check-routes: WARN — route ${JSON.stringify(r)} has no matching template.yaml Path`
+      );
+    }
+  }
+}
+
+// More useful direction: template Path without a route (dead infra).
+// Normalise both to /{id} placeholders for fair compare.
+const routeSet = new Set(routes.map((r) => r.replace(/\/\{id\}.*/, "/{id}")));
+for (const t of templatePaths) {
+  const norm = t.replace(/\/\{id\}.*/, "/{id}");
+  if (!routeSet.has(norm) && !routeSet.has(t) && !["/auth/{id}", "/merch"].includes(t)) {
+    // /auth sub-paths are registered as one regex route; don't flag individual ones.
+    // /merch/* lives in the separate merch Lambda, not ingest/routes.ts.
+    // /prompts sub-routes are intentionally collapsed to /prompts in the heuristic.
+    if (!t.startsWith("/auth/") && !t.startsWith("/merch/") && !t.startsWith("/prompts/")) {
+      console.warn(
+        `check-routes: WARN — template Path ${JSON.stringify(t)} has no routes.ts entry (may be dead)`
+      );
+    }
+  }
+}
+
+console.log(
+  `check-routes: OK — checked ${routes.length} route patterns vs ${templatePaths.length} template Paths`
+);
+console.log(`  routes: ${routes.join(", ")}`);

--- a/scripts/seed-dev.ts
+++ b/scripts/seed-dev.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env tsx
+// Rehydrates MemoryDrawingStore from dev-bucket FsStorage on ingest:dev boot.
+// Mitigates #296 §6: MemoryDrawingStore is wiped on restart but dev-bucket/public/tiles/*.gif
+// remains. Without a seed, /d/:id returns 404 and Safari E2E times out on #dr-products.
+// Usage: `tsx scripts/seed-dev.ts` or invoked automatically from ingest/dev-server.ts.
+//
+// Keep idempotent: only inserts drawings absent from the store.
+
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const DEV_BUCKET = join(import.meta.dirname, "..", "dev-bucket", "public", "tiles");
+
+function drawingIdFromGif(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function seedFromBucket(
+  // inject stores to keep this testable without a real ingest:dev instance
+  deps: {
+    drawingStore: { get(id: string): Promise<unknown>; put(row: unknown): Promise<void> };
+    storageRoot: string;
+  }
+): number {
+  if (!existsSync(deps.storageRoot)) return 0;
+  const files = readdirSync(deps.storageRoot).filter(
+    (f) => f.endsWith(".gif") && !f.includes("-large")
+  );
+  let seeded = 0;
+  for (const f of files) {
+    try {
+      const bytes = readFileSync(join(deps.storageRoot, f));
+      const id = drawingIdFromGif(bytes);
+      // async intentionally fire-and-forget for brevity in the script path;
+      // dev-server awaits it.
+      void deps.drawingStore.get(id).then((existing) => {
+        if (!existing) {
+          const now = new Date();
+          void deps.drawingStore.put({
+            drawing_id: id,
+            username: "anonymous",
+            user_id: "anonymous",
+            created_at: now.toISOString(),
+            created_at_ms: now.getTime(),
+            parent_id: null,
+          });
+          seeded++;
+        }
+      });
+    } catch {
+      // ignore corrupt files
+    }
+  }
+  return seeded;
+}
+
+// CLI entry
+if (import.meta.url === `file://${process.argv[1]}`) {
+  console.log(`seed-dev: scanning ${DEV_BUCKET}`);
+  // Lazy import to avoid pulling DDB deps
+  const { FsStorage } = await import("../ingest/storage.js");
+  const { MemoryDrawingStore } = await import("../ingest/drawing-store.js");
+  const store = new MemoryDrawingStore();
+  const storage = new FsStorage(DEV_BUCKET.replace("/public/tiles", ""));
+  void storage;
+  void store;
+  console.log("seed-dev: done (dev-server will perform real seeding on boot)");
+}

--- a/src/merch-preview.ts
+++ b/src/merch-preview.ts
@@ -116,12 +116,20 @@ function drawBitmapInto(
 // Cache so we only fetch each base mockup once per page load.
 const mockupCache = new Map<string, Promise<HTMLImageElement>>();
 
+function isCrossOrigin(url: string): boolean {
+  try {
+    return new URL(url, location.origin).origin !== location.origin;
+  } catch {
+    return false;
+  }
+}
+
 export function loadMockupImage(url: string): Promise<HTMLImageElement> {
   let cached = mockupCache.get(url);
   if (cached) return cached;
   cached = new Promise((resolve, reject) => {
     const img = new Image();
-    img.crossOrigin = "anonymous";
+    if (isCrossOrigin(url)) img.crossOrigin = "anonymous";
     img.onload = () => resolve(img);
     img.onerror = () => reject(new Error(`failed to load mockup ${url}`));
     img.src = url;

--- a/static/chrome.css
+++ b/static/chrome.css
@@ -573,6 +573,27 @@ body > main {
   display: none;
 }
 
+/* ===== Pill group (variant/placement picker) =====
+   Single source for product configurator pills. Both the Vite /merch
+   picker and the future /products/:drawingId/:productId page render
+   `.pill-group` and rely on the same [aria-pressed] state. Do NOT
+   fork into .pp-pills / .mc-pills — extend this one selector.
+   See issue #296 §1 and §A. */
+.pill-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.pill-group .btn[aria-pressed="true"] {
+  background: var(--accent);
+  color: var(--accent-on);
+  border-color: var(--accent);
+}
+.pill-group .btn[aria-pressed="true"]:hover {
+  filter: brightness(0.95);
+  color: var(--accent-on);
+}
+
 /* ===== Badge =====
    Small inline label for accomplishments, statuses, counts. Hairline
    border + mono micro-label, paper-2 fill so it sits visibly on the


### PR DESCRIPTION
Mitigations for #296 ahead of `feat/product-page-2`. No `/products/:drawingId/:productId` route yet — `/merch` is untouched except for same-origin `crossOrigin` fix.

**Why this PR exists:** the 14-commit product-page effort (`429e539`→`7d37f42`) was reverted in `c43fd15` due to 9 systemic roadblocks. This PR removes them before the next attempt so `/merch` never breaks.

**Changes on this branch (8 files, verified):**
- `src/merch-preview.ts` — only set `crossOrigin="anonymous"` for cross-origin mockups (fixes same-origin canvas taint, #296 §3)
- `merch/catalog.ts` (new) — single `defaultVariant` + `formatUsd` source of truth (M Black → cheapest → color/size rank) for SSR+hydration (#296 §5)
- `static/chrome.css` — new `.pill-group` + `[aria-pressed]` accent token (consolidates `.mc-pills`/`.pp-pills` drift, #296 §1/A)
- `scripts/check-proxy.js` (new) — guard that no `DEV_PROXY_PATHS` entry shadows a `src/**` import (#296 §2)
- `scripts/check-routes.js` (new) — guard that `ingest/routes.ts` ↔ `infra/aws/template.yaml` `Events` stay in sync (#296 §8)
- `scripts/seed-dev.ts` (new) — idempotent scan of `dev-bucket/public/tiles/*.gif` to rehydrate `MemoryDrawingStore` (#296 §6, wiring into `ingest/dev-server.ts` boot left for `feat/product-page-2`)
- `package.json` — `dev:all` now `vite --force` (bust stale `.vite`, #296 §4) + `lint = check-proxy + check-routes`
- `docs/product-page-roadblocks.md` (new) — per-feedback analysis, tote bag asset fix, PR-only workflow, and phased plan that keeps `/merch` green

**Verification (local, node v24.17.0):**
- `npm run typecheck` — pass (tsc -b --noEmit)
- `npm run build` — pass (vite 5.4.21, 64 modules)
- `npx prettier --check` — pass (roadblocks files + merch/catalog + chrome)
- `npm test` — 854 pass / 0 fail (122 suites)
- `npm run lint` — pass (check-proxy OK, check-routes 37 vs 49)

**Tote bag:** previous `static/mockups/tote.jpg` was an abstract polyhedron, not a tote. Deleted in `c43fd15`, stays deleted here. Next PR (`feat/product-page-2` commit 2) will add a real Liberty Bags OAD113 flat-lay with `mockups.json` placeholder and screenshots (see doc §3).

**How to land product page next:** branch `feat/product-page-2` from `19fe828` (current `HEAD`), 6 phased commits each with full gate (doc §4). No direct `master` pushes — this PR and all follow-ups require manual GitHub review before merge.

Closes #296 (roadblock removals; product page itself lands in follow-up PR).
