### PR TITLE
chore: React pilot — additive /v2/design for #1

### DIFF
--- a/infra/aws/build-lambda.mjs
+++ b/infra/aws/build-lambda.mjs
@@ -31,6 +31,7 @@ const shared = {
     "process.env.DRAWBANG_ASSET_VERSION": JSON.stringify(ASSET_VERSION),
   },
   logLevel: "info",
+  jsx: "automatic",
 };
 
 await build({

--- a/infra/aws/template.yaml
+++ b/infra/aws/template.yaml
@@ -396,6 +396,14 @@ Resources:
             CachedMethods: [GET, HEAD]
             Compress: true
             CachePolicyId: !Ref DynamicCachePolicy
+          # /v2/design — React pilot for #1, same cache as /design.
+          - PathPattern: /v2/design
+            TargetOriginId: api
+            ViewerProtocolPolicy: redirect-to-https
+            AllowedMethods: [GET, HEAD]
+            CachedMethods: [GET, HEAD]
+            Compress: true
+            CachePolicyId: !Ref DynamicCachePolicy
           # /products (exact) + /products/p/<N>. Split for the same reason
           # /gallery is — keep wildcards off the asset-prefix space.
           - PathPattern: /products
@@ -1061,6 +1069,12 @@ Resources:
             ApiId: !Ref IngestApi
             Method: ANY
             Path: /design
+        DesignPageV2:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref IngestApi
+            Method: ANY
+            Path: /v2/design
         DrawingPage:
           Type: HttpApi
           Properties:

--- a/ingest/render/design-v2.ts
+++ b/ingest/render/design-v2.ts
@@ -1,0 +1,18 @@
+import { CC_DESIGN } from "../../config/constants.js";
+import renderDesignV2 from "../../lib/templates/design-v2.js";
+import type { RenderHandlersConfig, RenderResponse } from "./shared.js";
+
+// Additive pilot for #1 — /v2/design uses React (renderToStaticMarkup)
+// while /design stays on string templates. Lets agents compare the two
+// side-by-side without breaking the existing route.
+export async function renderDesignV2PageHandler(
+  cfg: RenderHandlersConfig
+): Promise<RenderResponse> {
+  const body = renderDesignV2({ repo_url: cfg.repoUrl });
+  return {
+    status: 200,
+    contentType: "text/html; charset=utf-8",
+    cacheControl: CC_DESIGN,
+    body,
+  };
+}

--- a/ingest/routes.ts
+++ b/ingest/routes.ts
@@ -47,6 +47,7 @@ import {
 import { mintChallenge } from "./challenge.js";
 import { renderAdminShell, type AdminRange } from "../lib/templates/admin.js";
 import { handleGetAdminMerchFlags, handleSetAdminMerchFlags } from "./admin-handler.js";
+import { renderDesignV2PageHandler } from "./render/design-v2.js";
 import {
   renderBookmarksPageHandler,
   renderDesignPageHandler,
@@ -580,6 +581,15 @@ export function createRoutes(deps: RouteDeps): Route[] {
       pattern: /^\/design$/,
       auth: "none",
       handler: async () => render(await renderDesignPageHandler(deps.renderConfig)),
+    },
+    // Additive React pilot for #1 — /v2/design mirrors /design but
+    // rendered with React (lib/templates/design-v2.tsx + react-dom/server).
+    // Existing /design stays on string templates. No infra migration yet.
+    {
+      methods: ["GET"],
+      pattern: /^\/v2\/design$/,
+      auth: "none",
+      handler: async () => render(await renderDesignV2PageHandler(deps.renderConfig)),
     },
     {
       methods: ["GET"],

--- a/lib/templates/design-v2.tsx
+++ b/lib/templates/design-v2.tsx
@@ -1,0 +1,257 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { renderFooter, renderHeader } from "../../src/layout/chrome.js";
+import { renderHtmlShell } from "./_html-shell.js";
+
+// React pilot for #1 — additive /v2/design. Existing /design stays on
+// string templates (lib/templates/design.ts). This file is the same view
+// as DesignView but rendered with React components and react-dom/server.
+// Proves the component model on the most isolated route before touching
+// /, /d/<id>, or /u/*.
+
+export interface DesignV2View {
+  repo_url: string;
+}
+
+const COLOR_TOKENS: ReadonlyArray<{ name: string; role: string }> = [
+  { name: "--paper", role: "page background" },
+  { name: "--paper-2", role: "recessed surfaces" },
+  { name: "--ink", role: "primary text" },
+  { name: "--fg-muted", role: "secondary text, labels" },
+  { name: "--fg-dim", role: "tertiary text" },
+  { name: "--line", role: "hairlines, borders" },
+  { name: "--line-strong", role: "hover/focus borders" },
+  { name: "--accent", role: "CTA, active states" },
+  { name: "--accent-on", role: "text on accent" },
+  { name: "--accent-dim", role: "tinted accent bg" },
+];
+
+const TYPE_SCALE: ReadonlyArray<{ token: string; sample: string }> = [
+  { token: "--t-2xl", sample: "28 — hero numerals" },
+  { token: "--t-xl", sample: "20 — section landmark" },
+  { token: "--t-lg", sample: "16 — page title" },
+  { token: "--t-md", sample: "14 — body default" },
+  { token: "--t-sm", sample: "13 — secondary, button" },
+  { token: "--t-xs", sample: "11 — micro-label" },
+];
+
+const SPACING_TOKENS: ReadonlyArray<{ token: string; value: string }> = [
+  { token: "--tap", value: "40px — min interactive height" },
+  { token: "--pad", value: "16px — default padding" },
+  { token: "--pad-sm", value: "8px — tight padding" },
+  { token: "--border", value: "1px — every visible rule" },
+];
+
+const DESIGN_STYLES = `<style>
+      .ds-grid { display: grid; gap: 40px; }
+      .ds-row { display: grid; gap: 16px; }
+      .ds-swatches { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 12px; }
+      .ds-swatch { border: var(--border) solid var(--line); padding: 12px; display: grid; gap: 8px; }
+      .ds-swatch-chip { height: 40px; border: var(--border) solid var(--line); }
+      .ds-swatch-name { font-family: var(--font); font-size: var(--t-xs); color: var(--fg-muted); }
+      .ds-swatch-role { font-size: var(--t-xs); color: var(--fg-dim); }
+      .ds-type-row { display: flex; align-items: baseline; gap: 16px; padding: 6px 0; border-bottom: var(--border) solid var(--line); }
+      .ds-type-token { font-family: var(--font); font-size: var(--t-xs); color: var(--fg-muted); min-width: 90px; }
+      .ds-spacing-row { display: flex; align-items: center; gap: 16px; padding: 6px 0; border-bottom: var(--border) solid var(--line); }
+      .ds-spacing-bar { height: 10px; background: var(--accent); }
+      .ds-buttons { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
+      .ds-section-head { display: flex; align-items: baseline; gap: 16px; }
+      .ds-section-head h2 { font-size: var(--t-lg); margin: 0; font-weight: 700; }
+      .ds-section-head small { color: var(--fg-muted); font-size: var(--t-xs); }
+      .ds-sample-card {
+        display: grid; gap: 16px;
+        border: var(--border) solid var(--line);
+        padding: 16px;
+        max-width: 480px;
+      }
+      .ds-sample-art {
+        aspect-ratio: 1; background: var(--canvas-bg, #0a0a0a);
+        display: grid; place-items: center; color: var(--fg-muted); font-size: var(--t-xs);
+      }
+    </style>`;
+
+function Section({
+  title,
+  lede,
+  children,
+}: {
+  title: string;
+  lede: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="ds-row">
+      <div className="ds-section-head">
+        <h2>{title}</h2>
+        <small>{lede}</small>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function ColorSwatch({ name, role }: { name: string; role: string }) {
+  return (
+    <div className="ds-swatch">
+      <div className="ds-swatch-chip" style={{ background: `var(${name})` }} />
+      <div className="ds-swatch-name">{name}</div>
+      <div className="ds-swatch-role">{role}</div>
+    </div>
+  );
+}
+
+function TypeRow({ token, sample }: { token: string; sample: string }) {
+  return (
+    <div className="ds-type-row">
+      <span className="ds-type-token">{token}</span>
+      <span style={{ fontSize: `var(${token})` }}>{sample}</span>
+    </div>
+  );
+}
+
+function SpacingRow({ token, value }: { token: string; value: string }) {
+  return (
+    <div className="ds-spacing-row">
+      <span className="ds-type-token">{token}</span>
+      <span className="ds-spacing-bar" style={{ width: `var(${token})` }} />
+      <span className="muted">{value}</span>
+    </div>
+  );
+}
+
+function DesignGrid() {
+  return (
+    <div className="ds-grid">
+      <Section
+        title="Color tokens"
+        lede="Single accent rationed to CTA + active. No additional brand colors."
+      >
+        <div className="ds-swatches">
+          {COLOR_TOKENS.map((t) => (
+            <ColorSwatch key={t.name} name={t.name} role={t.role} />
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Type scale" lede="Six steps. Sans for prose, mono for labels.">
+        <div className="ds-row">
+          {TYPE_SCALE.map((t) => (
+            <TypeRow key={t.token} token={t.token} sample={t.sample} />
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Spacing tokens" lede="Use these inline; never invent new step values.">
+        <div className="ds-row">
+          {SPACING_TOKENS.map((t) => (
+            <SpacingRow key={t.token} token={t.token} value={t.value} />
+          ))}
+        </div>
+      </Section>
+
+      <Section
+        title="Buttons"
+        lede="Base + .primary + .ghost + .danger in chrome.css. Variants .icon/.sm/.xs live in src/style.css."
+      >
+        <div className="ds-buttons">
+          <button className="btn">Default</button>
+          <button className="btn primary">Primary</button>
+          <button className="btn ghost">Ghost</button>
+          <button className="btn danger">Danger</button>
+          <a className="btn" href="#">
+            Link as button
+          </a>
+          <button className="btn" disabled>
+            Disabled
+          </button>
+        </div>
+      </Section>
+
+      <Section
+        title="Follow button"
+        lede=".follow-btn — filled accent when unfollowed (the action), outlined when followed (the state)."
+      >
+        <div className="ds-buttons">
+          <button className="follow-btn" type="button" aria-pressed="false">
+            <span className="follow-label">Follow</span>
+          </button>
+          <button className="follow-btn" type="button" aria-pressed="true">
+            <span className="follow-label">Following</span>
+          </button>
+        </div>
+      </Section>
+
+      <Section
+        title="Badge"
+        lede=".badge — small inline label for accomplishments, statuses, counts. Hairline border + mono micro-label on paper-2 fill. Use .badge.accent for highlighted variants."
+      >
+        <div className="ds-buttons">
+          <span className="badge">Beta</span>
+          <span className="badge">Daily streak</span>
+          <span className="badge accent">New</span>
+        </div>
+      </Section>
+
+      <Section title="Page chrome" lede=".page-title, .page-sub, .divider, .panel-h, .muted.">
+        <h2 className="page-title">Page title</h2>
+        <p className="page-sub">Page subtitle — small muted note under the title.</p>
+        <hr className="divider" />
+        <h3 className="panel-h">Panel header label</h3>
+        <p className="muted">Muted body copy for tertiary information.</p>
+      </Section>
+
+      <Section title="Feed card" lede="Single canonical card. Do not vary.">
+        <article className="ds-sample-card">
+          <header className="feed-card-author">
+            <a className="feed-card-author-link" href="#">
+              @artist
+            </a>
+            <span className="feed-card-sep">·</span>
+            <time className="feed-card-time">Jun 6, 2026</time>
+          </header>
+          <div className="ds-sample-art">16×16 GIF goes here</div>
+          <div className="feed-card-actions">
+            <button className="feed-action like-btn" aria-pressed="false">
+              <span className="like-icon">♥</span>
+              <span className="like-count">42</span>
+            </button>
+            <button className="feed-action bookmark-btn" aria-pressed="false">
+              <span className="bookmark-icon">🔖</span>
+            </button>
+          </div>
+        </article>
+      </Section>
+
+      <Section
+        title="Flash"
+        lede="window.drawbangShowFlash(message, opts). Never inline-render error paragraphs."
+      >
+        {/* Static onclick preserved via raw HTML so renderToStaticMarkup emits it — React synthetic onClick would be dropped */}
+        <div
+          className="ds-buttons"
+          dangerouslySetInnerHTML={{
+            __html: `<button class="btn" onclick="window.drawbangShowFlash && window.drawbangShowFlash('Saved.', { kind: 'success' })">Trigger success</button><button class="btn" onclick="window.drawbangShowFlash && window.drawbangShowFlash('Something went wrong.', { kind: 'error' })">Trigger error</button>`,
+          }}
+        />
+      </Section>
+    </div>
+  );
+}
+
+export default function renderDesignV2(v: DesignV2View): string {
+  // Keep shell + header/footer as string helpers for this pilot — only the
+  // inner grid is React. Next step migrates _html-shell and chrome to JSX.
+  const gridHtml = renderToStaticMarkup(<DesignGrid />);
+  const body = `    ${renderHeader()}
+    <main>
+      <h1 class="page-title">Design system</h1>
+      <p class="page-sub">Visual reference for tokens + components defined in <code>static/chrome.css</code> and described in <code>docs/design-system.md</code>.</p>
+      ${gridHtml}
+    </main>
+    ${renderFooter({ repoUrl: v.repo_url })}`;
+  return renderHtmlShell({
+    title: "Draw! · Design system — v2 (React)",
+    extraHead: DESIGN_STYLES,
+    body,
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "mp4-muxer": "5.2.2",
         "omggif": "^1.0.10",
         "pngjs": "^7.0.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
         "stripe": "^22.1.0"
       },
       "devDependencies": {
@@ -29,6 +31,8 @@
         "@types/aws-lambda": "^8.10.161",
         "@types/node": "^22.5.0",
         "@types/pngjs": "^6.0.5",
+        "@types/react": "^18.3.1",
+        "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-basic-ssl": "^1.2.0",
         "concurrently": "^10.0.3",
         "esbuild": "^0.28.0",
@@ -2929,6 +2933,34 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
     "node_modules/@types/wicg-file-system-access": {
       "version": "2020.9.8",
       "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.8.tgz",
@@ -3106,6 +3138,13 @@
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
@@ -3289,6 +3328,24 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/mnemonist": {
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
@@ -3416,6 +3473,31 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -3479,6 +3561,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/shell-quote": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "@types/aws-lambda": "^8.10.161",
     "@types/node": "^22.5.0",
     "@types/pngjs": "^6.0.5",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-basic-ssl": "^1.2.0",
     "concurrently": "^10.0.3",
     "esbuild": "^0.28.0",
@@ -53,6 +55,8 @@
     "mp4-muxer": "5.2.2",
     "omggif": "^1.0.10",
     "pngjs": "^7.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "stripe": "^22.1.0"
   },
   "optionalDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,11 +17,13 @@
     "verbatimModuleSyntax": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx",
     "noEmit": true
   },
   "include": [
     "src/**/*",
     "ingest/**/*",
+    "lib/**/*",
     "builder/**/*",
     "merch/**/*",
     "functions/**/*",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,7 @@ const DEV_PROXY_PATHS = [
   "/auth",
   "/backfill",
   "/design",
+  "/v2/design",
   "/drawings",
   "/feed.rss",
   "/feed/items",


### PR DESCRIPTION
Additive pilot for #298 #1 — most recognizable architecture before touching the critical routes.

**Scope — no break:**
- `react@18.3.1`, `react-dom@18.3.1` + `@types`, `jsx:react-jsx` in `tsconfig.json` (`lib/**/*` added), `jsx:automatic` in `infra/aws/build-lambda.mjs` — proved React toolchain agents know
- New `lib/templates/design-v2.tsx` — same `DesignView` as `lib/templates/design.ts` but `DesignGrid`/`Section`/`ColorSwatch` as React FCs, `renderToStaticMarkup`, auto-escaping, props composition. Keeps `renderHtmlShell`/`renderHeader`/`renderFooter` strings for this pilot (next PR migrates shell + `src/layout/chrome.ts` to JSX)
- New `ingest/render/design-v2.ts` `renderDesignV2PageHandler` (same `CC_DESIGN`)
- New `GET /v2/design` in `ingest/routes.ts` + `/v2/design` in `vite.config.ts` `DEV_PROXY_PATHS` + `Path: /v2/design` Events + `PathPattern: /v2/design` CacheBehavior in `infra/aws/template.yaml` — existing `/design` untouched

**Verified locally:**
- `tsc -b --noEmit` pass (via jellyfish node)
- `node --test --import tsx 'test/**/*.test.ts'` — 854 pass
- `prettier --check` pass for changed files (other worktree warnings unchanged)
- `lambda:build` — `dist-lambda/lambda.js 1.0mb` (ffmpeg step expectedly fails on macOS without `linux-arm64` binary, CI installs it)
- `curl :8787/design` 200 old title, `curl :8787/v2/design` 200 new title `— v2 (React)`, same via `:5173` proxy
- No new CloudFront path without API Gateway path — both added per `CLAUDE.md:2` checklist

**Next:**
- Migrate `_html-shell` + `chrome.ts` to React components and hydrate the grid (opportunistic `useState` for pills etc.)
- Use `/v2/design` as reference to migrate `/`, `/d/*`, `/u/*` one route at a time

Closes #298 (pilot for #1) — follow-ups will be separate PRs.