### PR TITLE
docs: require PR for all changes — remove direct push to master

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ Env: `VITE_INGEST_URL`, `VITE_DRAWING_BASE_URL` (editor build); Lambda runtime `
 - No WHAT comments — WHY only when non-obvious.
 - Tests: `node:test` + `tsx`, no new framework.
 - Storage via `Storage` interface (`FsStorage` ↔ `S3Storage` interchangeable).
-- Merge to `master` when green (typecheck + tests); no review gate. Deploy runs on every push. End-of-task flow: `typecheck` → `test` (iterate to green) → commit → push → smoke-check `pixel.drawbang.com` after deploy. Ask only for destructive actions (force-push, data removal).
+- All changes via PR — do not push directly to `master`. End-of-task flow: `typecheck` → `test` (iterate to green) → commit → push branch → open PR → merge after green → smoke-check `pixel.drawbang.com` after deploy. Ask only for destructive actions (force-push, data removal).
 - Naming: kebab-case files, PascalCase types (`UserRecord`), camelCase fns/vars (`activePalette`, `is/has/can/should` for booleans), `UPPER_SNAKE_CASE` constants (`MAX_FRAMES`), namespaced CSS (`.dr-`, `.ow-`, `.pr-`, `.ed-`, `.mc-`), `*.worker.ts`/`*.test.ts` when relevant. On rename, update imports + docs + run `typecheck` in same commit.
 - UI consistency: search the repo before adding any visible affordance; reuse `src/layout/flash.ts` / `static/flash.js`, `src/layout/chrome.ts` markers, `.btn`/`.ghost`/`.primary` in `chrome.css`, `src/layout/tracking.ts`. If a Lambda page needs a Vite helper, lift to `static/*.js` + `chrome.css` + `window.drawbang*` rather than duplicating.
 


### PR DESCRIPTION
Updates CLAUDE.md §8 conventions: was "Merge to master when green; no review gate" — now "All changes via PR — do not push directly to master". Keeps df749dc (noscale test) on master as you requested, but documents the new workflow for subagents.

End-of-task flow now: typecheck → test → commit → push branch → open PR → merge after green → smoke-check pixel.drawbang.com