### PR TITLE
refactor: share BrutalShell chrome between v2/design and viewport_debug

### DIFF
--- a/lib/templates/brutal-shell.tsx
+++ b/lib/templates/brutal-shell.tsx
@@ -1,0 +1,174 @@
+import * as React from "react";
+import { assetUrl } from "../../src/layout/asset-version.js";
+import { LOGO_SVG } from "../../src/layout/logo.js";
+import { renderAnalyticsInner, renderMetaPixelInner } from "../../src/layout/tracking.js";
+
+export type BrutalVariant = "original" | "fixed" | "noscale";
+
+const BRUTAL_ACCENT = "#00ffcc";
+
+const BASE_FONT_FACE = `@font-face{font-family:"Departure Mono";src:url("/fonts/DepartureMono-Regular.woff2") format("woff2"),url("/fonts/DepartureMono-Regular.woff") format("woff"),url("/fonts/DepartureMono-Regular.otf") format("opentype");font-display:swap;font-feature-settings:"locl"}`;
+
+const BASE_RESET = `*{font-family:"Departure Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace} html{font-synthesis:none;text-rendering:geometricPrecision;-webkit-font-smoothing:none;-moz-osx-font-smoothing:unset;font-smooth:never;image-rendering:pixelated} *{font-variant-ligatures:none;font-feature-settings:"locl"}`;
+
+const TEXT_PIXEL_ORIGINAL = `.text-pixel-2x{font-size:11px!important;line-height:14px!important;display:inline-block;transform:scale(2);transform-origin:left center;image-rendering:pixelated} h1.text-pixel-2x,h2.text-pixel-2x{display:block;transform-origin:left top;margin-bottom:11px}`;
+
+const TEXT_PIXEL_FIXED = `${TEXT_PIXEL_ORIGINAL} .text-pixel-2x{max-width:50%} h1.text-pixel-2x,h2.text-pixel-2x{width:50%;max-width:50%;overflow-wrap:anywhere;word-break:break-word} html,body{overflow-x:hidden;max-width:100vw}`;
+
+const TEXT_PIXEL_NOSCALE = `${BASE_FONT_FACE} ${BASE_RESET} .text-pixel-2x{font-size:22px!important;line-height:22px!important;display:block;transform:none;image-rendering:pixelated;font-weight:400!important} h1.text-pixel-2x,h2.text-pixel-2x{display:block;transform:none;margin-bottom:0;font-weight:400!important}`;
+
+export function brutalStyleForVariant(variant: BrutalVariant = "original"): string {
+  if (variant === "noscale") return TEXT_PIXEL_NOSCALE;
+  if (variant === "fixed") return `${BASE_FONT_FACE} ${BASE_RESET} ${TEXT_PIXEL_FIXED}`;
+  return `${BASE_FONT_FACE} ${BASE_RESET} ${TEXT_PIXEL_ORIGINAL} .hdr-logo svg{height:22px;width:auto;display:block}`;
+}
+
+const SHARED_HDR_LOGO_STYLE = `.hdr-logo svg{height:22px;width:auto;display:block}`;
+
+export function getBrutalStyle(variant: BrutalVariant = "original"): string {
+  const base = brutalStyleForVariant(variant);
+  if (variant === "original" && !base.includes("hdr-logo")) {
+    return `${base} ${SHARED_HDR_LOGO_STYLE}`;
+  }
+  if (variant === "fixed" && !base.includes("hdr-logo")) {
+    return `${base} ${SHARED_HDR_LOGO_STYLE}`;
+  }
+  return base;
+}
+
+export function BrutalHeader() {
+  return (
+    <header className="sticky top-0 z-10 border-b border-black bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80">
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-3 sm:px-6 lg:px-8">
+        <a
+          href="/"
+          aria-label="Draw! home"
+          className="hdr-logo inline-flex items-center hover:opacity-80"
+          dangerouslySetInnerHTML={{ __html: LOGO_SVG }}
+        />
+        <nav className="hidden sm:flex items-center gap-2 text-pixel">
+          <a
+            href="/products"
+            className="rounded-[4px] border border-black bg-white px-3 py-1.5 hover:bg-zinc-50"
+          >
+            Products
+          </a>
+          <a
+            href="/draw"
+            className="rounded-[4px] border border-black bg-[#00ffcc] px-3 py-1.5 font-medium hover:bg-[#00ffcc]/90"
+          >
+            New drawing
+          </a>
+          <a
+            href="/login"
+            className="rounded-[4px] border border-black bg-white px-3 py-1.5 hover:bg-zinc-50"
+          >
+            Sign in
+          </a>
+        </nav>
+        <a
+          href="/draw"
+          className="sm:hidden inline-flex items-center rounded-[4px] border border-black bg-[#00ffcc] px-3 py-2 text-pixel font-medium"
+        >
+          Draw
+        </a>
+      </div>
+    </header>
+  );
+}
+
+export function BrutalFooter({ repoUrl }: { repoUrl: string }) {
+  return (
+    <footer className="border border-black rounded-[4px] bg-white p-4 text-pixel text-zinc-600 flex flex-col sm:flex-row gap-2 sm:items-center sm:justify-between">
+      <span className="font-mono">
+        Draw! — brutalist, mono, 1px round •{" "}
+        <a href="/privacy" className="underline decoration-black underline-offset-2">
+          Privacy
+        </a>{" "}
+        •{" "}
+        <a
+          href="https://github.com/potomak/drawbang/issues/new?labels=feedback"
+          className="underline decoration-black underline-offset-2"
+        >
+          Feedback
+        </a>
+      </span>
+      <a
+        href={repoUrl}
+        className="rounded-[4px] border border-black bg-zinc-50 px-2 py-1 font-mono text-pixel hover:bg-white"
+      >
+        {repoUrl.replace("https://", "")}
+      </a>
+    </footer>
+  );
+}
+
+export interface BrutalShellProps {
+  title: string;
+  repoUrl: string;
+  variant?: BrutalVariant;
+  children: React.ReactNode;
+  includeHydrate?: boolean;
+  extraHead?: React.ReactNode;
+  extraBody?: React.ReactNode;
+  header?: React.ReactNode;
+  footer?: React.ReactNode;
+}
+
+export function BrutalShell({
+  title,
+  repoUrl,
+  variant = "original",
+  children,
+  includeHydrate = false,
+  extraHead,
+  extraBody,
+  header,
+  footer,
+}: BrutalShellProps) {
+  const tailwindConfig = `tailwind.config={theme:{extend:{colors:{paper:'#ffffff','paper-2':'#f7f7f5',ink:'#0a0a0a',line:'#0a0a0a',accent:'${BRUTAL_ACCENT}','accent-on':'#0a0a0a'},fontFamily:{mono:['Departure Mono','ui-monospace','SFMono-Regular','Menlo','Consolas','monospace'],sans:['Departure Mono','ui-monospace','SFMono-Regular','Menlo','Consolas','monospace']},borderRadius:{brutal:'4px'},fontSize:{pixel:['11px','14px'],'pixel-2x':['22px','22px']}}}}`;
+  const brutalStyle = getBrutalStyle(variant);
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <title>{title}</title>
+        <script src="https://cdn.tailwindcss.com" />
+        <script dangerouslySetInnerHTML={{ __html: tailwindConfig }} />
+        <link
+          rel="preload"
+          href="/fonts/DepartureMono-Regular.woff2"
+          as="font"
+          type="font/woff2"
+          crossOrigin="anonymous"
+        />
+        <style dangerouslySetInnerHTML={{ __html: brutalStyle }} />
+        {extraHead}
+        <script dangerouslySetInnerHTML={{ __html: renderAnalyticsInner() }} />
+        <script dangerouslySetInnerHTML={{ __html: renderMetaPixelInner() }} />
+        {includeHydrate &&
+          (() => {
+            const hydrateSrc = process.env.DRAWBANG_ASSET_VERSION
+              ? assetUrl("/assets/hydrate-v2-design.js")
+              : "/src/hydrate-v2-design.tsx";
+            return <script type="module" src={hydrateSrc} />;
+          })()}
+      </head>
+      <body className="bg-white text-black font-mono antialiased">
+        {header ?? <BrutalHeader />}
+        <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+          <div className="flex flex-col gap-6 sm:gap-8">
+            {children}
+            {footer ?? <BrutalFooter repoUrl={repoUrl} />}
+          </div>
+        </div>
+        <script src={assetUrl("/flash.js")} />
+        <script src={assetUrl("/chrome-toggle.js")} />
+        <script src={assetUrl("/chrome-identity.js")} />
+        <script src={assetUrl("/hydrate.js")} />
+        {extraBody}
+      </body>
+    </html>
+  );
+}

--- a/lib/templates/design-v2-viewport-debug.tsx
+++ b/lib/templates/design-v2-viewport-debug.tsx
@@ -1,187 +1,27 @@
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { assetUrl } from "../../src/layout/asset-version.js";
 import { LOGO_SVG } from "../../src/layout/logo.js";
-import { renderAnalyticsInner, renderMetaPixelInner } from "../../src/layout/tracking.js";
+import { BrutalShell, type BrutalVariant } from "./brutal-shell.js";
 
 export interface ViewportDebugView {
   repo_url: string;
 }
 
-// Original BrutalShell CSS without overflow fixes — to isolate the bug
-const DEBUG_STYLE_ORIGINAL = `@font-face{font-family:"Departure Mono";src:url("/fonts/DepartureMono-Regular.woff2") format("woff2"),url("/fonts/DepartureMono-Regular.woff") format("woff"),url("/fonts/DepartureMono-Regular.otf") format("opentype");font-display:swap;font-feature-settings:"locl"} *{font-family:"Departure Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace} html{font-synthesis:none;text-rendering:geometricPrecision;-webkit-font-smoothing:none;-moz-osx-font-smoothing:unset;font-smooth:never;image-rendering:pixelated} *{font-variant-ligatures:none;font-feature-settings:"locl"} .text-pixel-2x{font-size:11px!important;line-height:14px!important;display:inline-block;transform:scale(2);transform-origin:left center;image-rendering:pixelated} h1.text-pixel-2x,h2.text-pixel-2x{display:block;transform-origin:left top;margin-bottom:11px}`;
-
-const DEBUG_STYLE_FIXED = `${DEBUG_STYLE_ORIGINAL} .text-pixel-2x{max-width:50%} h1.text-pixel-2x,h2.text-pixel-2x{width:50%;max-width:50%;overflow-wrap:anywhere;word-break:break-word} html,body{overflow-x:hidden;max-width:100vw}`;
-
-// Test without scale — font-size 22 directly, no synthetic bold (Departure Mono has no bold cut)
-const DEBUG_STYLE_NOSCALE = `@font-face{font-family:"Departure Mono";src:url("/fonts/DepartureMono-Regular.woff2") format("woff2"),url("/fonts/DepartureMono-Regular.woff") format("woff"),url("/fonts/DepartureMono-Regular.otf") format("opentype");font-display:swap;font-feature-settings:"locl"} *{font-family:"Departure Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace} html{font-synthesis:none;text-rendering:geometricPrecision;-webkit-font-smoothing:none;-moz-osx-font-smoothing:unset;font-smooth:never;image-rendering:pixelated} *{font-variant-ligatures:none;font-feature-settings:"locl"} .text-pixel-2x{font-size:22px!important;line-height:22px!important;display:block;transform:none;image-rendering:pixelated;font-weight:400!important} h1.text-pixel-2x,h2.text-pixel-2x{display:block;transform:none;margin-bottom:0;font-weight:400!important}`;
-
-function ViewportDebugShell({
-  variant,
-  children,
-}: {
-  variant: "original" | "fixed" | "noscale";
-  children: React.ReactNode;
-}) {
-  const style =
-    variant === "noscale"
-      ? DEBUG_STYLE_NOSCALE
-      : variant === "fixed"
-        ? DEBUG_STYLE_FIXED
-        : DEBUG_STYLE_ORIGINAL;
-  const tailwindConfig = `tailwind.config={theme:{extend:{colors:{paper:'#ffffff','paper-2':'#f7f7f5',ink:'#0a0a0a',line:'#0a0a0a',accent:'#00ffcc','accent-on':'#0a0a0a'},fontFamily:{mono:['Departure Mono','ui-monospace','SFMono-Regular','Menlo','Consolas','monospace'],sans:['Departure Mono','ui-monospace','SFMono-Regular','Menlo','Consolas','monospace']},borderRadius:{brutal:'4px'},fontSize:{pixel:['11px','14px'],'pixel-2x':['22px','22px']}}}}`;
+function ViewportDebugHeader() {
   return (
-    <html lang="en">
-      <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
-        <title>Viewport debug — v2/design</title>
-        <script src="https://cdn.tailwindcss.com" />
-        <script dangerouslySetInnerHTML={{ __html: tailwindConfig }} />
-        <link
-          rel="preload"
-          href="/fonts/DepartureMono-Regular.woff2"
-          as="font"
-          type="font/woff2"
-          crossOrigin="anonymous"
-        />
-        <style dangerouslySetInnerHTML={{ __html: style }} />
-        <style
-          dangerouslySetInnerHTML={{
-            __html: `.debug-on{outline:2px solid #ff3b30}.debug-badge{position:fixed;bottom:12px;left:12px;right:12px;z-index:50;background:#0a0a0a;color:#fff;border:1px solid #fff;border-radius:4px;padding:8px 12px;font-family:"Departure Mono",monospace;font-size:11px;line-height:14px} .debug-badge.ok{background:#00a86b} .debug-badge.warn{background:#b00020} .hdr-logo svg{height:22px;width:auto;display:block} .hdr-logo-16 svg{height:16px;width:auto;display:block}`,
-          }}
-        />
-        <script dangerouslySetInnerHTML={{ __html: renderAnalyticsInner() }} />
-        <script dangerouslySetInnerHTML={{ __html: renderMetaPixelInner() }} />
-      </head>
-      <body className="bg-white text-black font-mono antialiased">
-        <header className="sticky top-0 z-10 border-b border-black bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80">
-          <div className="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-3 sm:px-6 lg:px-8">
-            <a
-              href="/"
-              aria-label="Draw! home"
-              className="inline-flex items-center hover:opacity-80"
-            >
-              <span className="hdr-logo" dangerouslySetInnerHTML={{ __html: LOGO_SVG }} />
-              <span className="ml-2 text-pixel text-zinc-500 hidden sm:inline">v1 22px</span>
-            </a>
-            <a
-              href="/"
-              aria-label="Draw! home"
-              className="inline-flex items-center hover:opacity-80"
-            >
-              <span className="hdr-logo-16" dangerouslySetInnerHTML={{ __html: LOGO_SVG }} />
-              <span className="ml-2 text-pixel text-zinc-500 hidden sm:inline">v2 16px (bug)</span>
-            </a>
-            <span className="text-pixel text-zinc-600">debug</span>
-          </div>
-        </header>
-        <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-6">
-          <div className="mb-4 rounded-[4px] border border-black bg-[#00ffcc]/20 p-3 font-mono text-pixel">
-            <div className="font-bold">Viewport debug playground — /v2/design/viewport_debug</div>
-            <div className="text-zinc-600">
-              Toggle sections one by one on a small viewport (≤390px) to see which causes horizontal
-              scroll. Red outline = element wider than viewport.
-            </div>
-            <div className="mt-2 flex flex-wrap gap-2 text-pixel">
-              <span className="rounded-[4px] border border-black bg-white px-2 py-1">
-                Variant: <strong>{variant}</strong>
-              </span>
-              <a
-                href="?variant=original"
-                className={`rounded-[4px] border border-black px-2 py-1 ${variant === "original" ? "bg-[#00ffcc]" : "bg-white"}`}
-              >
-                original (scale 2x)
-              </a>
-              <a
-                href="?variant=fixed"
-                className={`rounded-[4px] border border-black px-2 py-1 ${variant === "fixed" ? "bg-[#00ffcc]" : "bg-white"}`}
-              >
-                fixed (scale 2x + width:50%)
-              </a>
-              <a
-                href="?variant=noscale"
-                className={`rounded-[4px] border border-black px-2 py-1 ${variant === "noscale" ? "bg-[#00ffcc]" : "bg-white"}`}
-              >
-                noscale (22px, no bold)
-              </a>
-            </div>
-            <div className="mt-2 text-pixel text-zinc-600">
-              <code className="bg-white border border-black rounded-[4px] px-1">fixed</code>:{" "}
-              <code className="bg-white border border-black rounded-[4px] px-1">
-                h1.text-pixel-2x width:50%
-              </code>{" "}
-              so visual 22px wraps at 50% layout.{" "}
-              <code className="bg-white border border-black rounded-[4px] px-1">noscale</code>:{" "}
-              <code className="bg-white border border-black rounded-[4px] px-1">
-                .text-pixel-2x font-size:22px; transform:none; font-weight:400
-              </code>{" "}
-              — no synthetic bold.
-            </div>
-            <label className="mt-2 hidden">
-              <input
-                type="checkbox"
-                id="debug-fix-toggle"
-                defaultChecked={variant !== "original"}
-              />
-            </label>
-          </div>
-          {children}
-        </div>
-        <div id="debug-badge" className="debug-badge">
-          measuring…
-        </div>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-(function(){
-  var badge=document.getElementById('debug-badge');
-  // Highlight any element wider than viewport
-  function check(){
-    var vw=window.innerWidth;
-    var sw=document.documentElement.scrollWidth;
-    var overflow=sw>vw;
-    var variant=new URLSearchParams(location.search).get('variant')|| (new URLSearchParams(location.search).get('fix')==='0'?'original':'fixed');
-    var msg='vw:'+vw+' scrollWidth:'+sw+' '+(overflow?'OVERFLOW ':'ok ')+'| variant:'+variant;
-    // find widest element
-    var widest=null, maxW=0;
-    document.querySelectorAll('[data-debug]').forEach(function(el){
-      el.classList.remove('debug-on');
-      var r=el.getBoundingClientRect();
-      if(r.width>maxW){maxW=r.width; widest=el;}
-      if(r.right>vw+0.5 || r.width>vw+0.5){
-        el.classList.add('debug-on');
-      }
-    });
-    if(widest){
-      msg+=' | widest:'+widest.getAttribute('data-debug')+'('+Math.round(maxW)+'px)';
-    }
-    badge.textContent=msg;
-    badge.className='debug-badge '+(overflow?'warn':'ok');
-  }
-  window.addEventListener('resize',check);
-  window.addEventListener('load',check);
-  setTimeout(check,100);
-  // Toggle visibility via checkboxes
-  document.querySelectorAll('[data-debug-toggle]').forEach(function(cb){
-    cb.addEventListener('change',function(){
-      var id=cb.getAttribute('data-debug-toggle');
-      var el=document.querySelector('[data-debug="'+id+'"]');
-      if(el) el.hidden=!cb.checked;
-      setTimeout(check,50);
-    });
-  });
-  check();
-})();
-`,
-          }}
-        />
-        <script src={assetUrl("/flash.js")} />
-        <script src={assetUrl("/chrome-toggle.js")} />
-        <script src={assetUrl("/chrome-identity.js")} />
-        <script src={assetUrl("/hydrate.js")} />
-      </body>
-    </html>
+    <header className="sticky top-0 z-10 border-b border-black bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80">
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-3 sm:px-6 lg:px-8">
+        <a href="/" aria-label="Draw! home" className="inline-flex items-center hover:opacity-80">
+          <span className="hdr-logo" dangerouslySetInnerHTML={{ __html: LOGO_SVG }} />
+          <span className="ml-2 text-pixel text-zinc-500 hidden sm:inline">v1 22px</span>
+        </a>
+        <a href="/" aria-label="Draw! home" className="inline-flex items-center hover:opacity-80">
+          <span className="hdr-logo-16" dangerouslySetInnerHTML={{ __html: LOGO_SVG }} />
+          <span className="ml-2 text-pixel text-zinc-500 hidden sm:inline">v2 16px (bug)</span>
+        </a>
+        <span className="text-pixel text-zinc-600">debug</span>
+      </div>
+    </header>
   );
 }
 
@@ -213,12 +53,120 @@ function DebugSection({
 export default function renderViewportDebug(
   v: ViewportDebugView & { useFix?: boolean; variant?: string }
 ): string {
-  // Back-compat: ?fix=0/1 maps to original/fixed, ?variant takes precedence
   const variant =
-    (v.variant as "original" | "fixed" | "noscale") ??
+    (v.variant as BrutalVariant) ??
     (v.useFix === false ? "original" : v.useFix === true ? "fixed" : "fixed");
+
+  const debugExtraHead = (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: `.debug-on{outline:2px solid #ff3b30}.debug-badge{position:fixed;bottom:12px;left:12px;right:12px;z-index:50;background:#0a0a0a;color:#fff;border:1px solid #fff;border-radius:4px;padding:8px 12px;font-family:"Departure Mono",monospace;font-size:11px;line-height:14px} .debug-badge.ok{background:#00a86b} .debug-badge.warn{background:#b00020} .hdr-logo svg{height:22px;width:auto;display:block} .hdr-logo-16 svg{height:16px;width:auto;display:block}`,
+      }}
+    />
+  );
+
+  const debugExtraBody = (
+    <>
+      <div id="debug-badge" className="debug-badge">
+        measuring…
+      </div>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `
+(function(){
+  var badge=document.getElementById('debug-badge');
+  function check(){
+    var vw=window.innerWidth;
+    var sw=document.documentElement.scrollWidth;
+    var overflow=sw>vw;
+    var variant=new URLSearchParams(location.search).get('variant')|| (new URLSearchParams(location.search).get('fix')==='0'?'original':'fixed');
+    var msg='vw:'+vw+' scrollWidth:'+sw+' '+(overflow?'OVERFLOW ':'ok ')+'| variant:'+variant;
+    var widest=null, maxW=0;
+    document.querySelectorAll('[data-debug]').forEach(function(el){
+      el.classList.remove('debug-on');
+      var r=el.getBoundingClientRect();
+      if(r.width>maxW){maxW=r.width; widest=el;}
+      if(r.right>vw+0.5 || r.width>vw+0.5){
+        el.classList.add('debug-on');
+      }
+    });
+    if(widest){
+      msg+=' | widest:'+widest.getAttribute('data-debug')+'('+Math.round(maxW)+'px)';
+    }
+    badge.textContent=msg;
+    badge.className='debug-badge '+(overflow?'warn':'ok');
+  }
+  window.addEventListener('resize',check);
+  window.addEventListener('load',check);
+  setTimeout(check,100);
+  document.querySelectorAll('[data-debug-toggle]').forEach(function(cb){
+    cb.addEventListener('change',function(){
+      var id=cb.getAttribute('data-debug-toggle');
+      var el=document.querySelector('[data-debug="'+id+'"]');
+      if(el) el.hidden=!cb.checked;
+      setTimeout(check,50);
+    });
+  });
+  check();
+})();
+`,
+        }}
+      />
+    </>
+  );
+
   const html = renderToStaticMarkup(
-    <ViewportDebugShell variant={variant}>
+    <BrutalShell
+      title="Viewport debug — v2/design"
+      repoUrl={v.repo_url}
+      variant={variant}
+      header={<ViewportDebugHeader />}
+      extraHead={debugExtraHead}
+      extraBody={debugExtraBody}
+    >
+      <div className="mb-4 rounded-[4px] border border-black bg-[#00ffcc]/20 p-3 font-mono text-pixel">
+        <div className="font-bold">Viewport debug playground — /v2/design/viewport_debug</div>
+        <div className="text-zinc-600">
+          Toggle sections one by one on a small viewport (≤390px) to see which causes horizontal
+          scroll. Red outline = element wider than viewport.
+        </div>
+        <div className="mt-2 flex flex-wrap gap-2 text-pixel">
+          <span className="rounded-[4px] border border-black bg-white px-2 py-1">
+            Variant: <strong>{variant}</strong>
+          </span>
+          <a
+            href="?variant=original"
+            className={`rounded-[4px] border border-black px-2 py-1 ${variant === "original" ? "bg-[#00ffcc]" : "bg-white"}`}
+          >
+            original (scale 2x)
+          </a>
+          <a
+            href="?variant=fixed"
+            className={`rounded-[4px] border border-black px-2 py-1 ${variant === "fixed" ? "bg-[#00ffcc]" : "bg-white"}`}
+          >
+            fixed (scale 2x + width:50%)
+          </a>
+          <a
+            href="?variant=noscale"
+            className={`rounded-[4px] border border-black px-2 py-1 ${variant === "noscale" ? "bg-[#00ffcc]" : "bg-white"}`}
+          >
+            noscale (22px, no bold)
+          </a>
+        </div>
+        <div className="mt-2 text-pixel text-zinc-600">
+          <code className="bg-white border border-black rounded-[4px] px-1">fixed</code>:{" "}
+          <code className="bg-white border border-black rounded-[4px] px-1">
+            h1.text-pixel-2x width:50%
+          </code>{" "}
+          so visual 22px wraps at 50% layout.{" "}
+          <code className="bg-white border border-black rounded-[4px] px-1">noscale</code>:{" "}
+          <code className="bg-white border border-black rounded-[4px] px-1">
+            .text-pixel-2x font-size:22px; transform:none; font-weight:400
+          </code>{" "}
+          — no synthetic bold.
+        </div>
+      </div>
+
       <div className="flex flex-col gap-6">
         <DebugSection id="intro" title="Intro — h1.text-pixel-2x (suspect)">
           <div className="rounded-[4px] border border-dashed border-zinc-400 p-2 text-pixel text-zinc-600">
@@ -261,12 +209,8 @@ export default function renderViewportDebug(
         <DebugSection id="borders" title="Borders — grid 1 col">
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             <div className="rounded-[4px] border border-black bg-white p-4 text-pixel">border</div>
-            <div className="rounded-[4px] border border-black bg-[#00ffcc] p-4 text-pixel">
-              accent
-            </div>
-            <div className="rounded-[4px] border border-black bg-zinc-50 p-4 text-pixel">
-              recessed
-            </div>
+            <div className="rounded-[4px] border border-black bg-[#00ffcc] p-4 text-pixel">accent</div>
+            <div className="rounded-[4px] border border-black bg-zinc-50 p-4 text-pixel">recessed</div>
           </div>
         </DebugSection>
 
@@ -304,7 +248,7 @@ export default function renderViewportDebug(
           </footer>
         </DebugSection>
       </div>
-    </ViewportDebugShell>
+    </BrutalShell>
   );
   return `<!doctype html>\n${html}`;
 }

--- a/lib/templates/design-v2.tsx
+++ b/lib/templates/design-v2.tsx
@@ -1,24 +1,17 @@
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { assetUrl } from "../../src/layout/asset-version.js";
-import { LOGO_SVG } from "../../src/layout/logo.js";
-import { renderAnalyticsInner, renderMetaPixelInner } from "../../src/layout/tracking.js";
 import { FlashDemo } from "../../src/components/FlashDemo.js";
-
-// Brutalist v2 design system — mobile-first, mono everywhere, 1px round borders, accent #00ffcc
-// Playground for #1 + Tailwind. Additive: /design stays on chrome.css, /v2/design is the new standard.
+import { BrutalShell } from "./brutal-shell.js";
 
 export interface DesignV2View {
   repo_url: string;
 }
 
-const BRUTAL_ACCENT = "#00ffcc";
-
 const COLOR_TOKENS: ReadonlyArray<{ name: string; hex: string; role: string }> = [
   { name: "--paper", hex: "#ffffff", role: "page background" },
   { name: "--paper-2", hex: "#f7f7f5", role: "recessed surface" },
   { name: "--ink", hex: "#0a0a0a", role: "primary text / line" },
-  { name: "--accent", hex: BRUTAL_ACCENT, role: "CTA, active, focus" },
+  { name: "--accent", hex: "#00ffcc", role: "CTA, active, focus" },
   { name: "--accent-on", hex: "#0a0a0a", role: "text on accent" },
   { name: "--fg-muted", hex: "#52525b", role: "secondary text" },
 ];
@@ -27,156 +20,6 @@ const TYPE_SCALE: ReadonlyArray<{ label: string; cls: string; sample: string }> 
   { label: "text-pixel", cls: "text-pixel", sample: "11 — body / badge / button (1×)" },
   { label: "text-pixel-2x", cls: "text-pixel-2x", sample: "22 — title / hero (2×)" },
 ];
-
-function BrutalShell({
-  title,
-  repoUrl,
-  children,
-}: {
-  title: string;
-  repoUrl: string;
-  children: React.ReactNode;
-}) {
-  // Tailwind CDN for pilot — mobile-first, no build step for Lambda.
-  // In prod the same CDN + purged static/tailwind.css will be cached; Vite's @tailwindcss/vite
-  // handles the SPA side via src/styles/tailwind.css. Keeping both for overlap during migration.
-  const tailwindConfig = `tailwind.config={theme:{extend:{colors:{paper:'#ffffff','paper-2':'#f7f7f5',ink:'#0a0a0a',line:'#0a0a0a',accent:'${BRUTAL_ACCENT}','accent-on':'#0a0a0a'},fontFamily:{mono:['Departure Mono','ui-monospace','SFMono-Regular','Menlo','Consolas','monospace'],sans:['Departure Mono','ui-monospace','SFMono-Regular','Menlo','Consolas','monospace']},borderRadius:{brutal:'4px'},fontSize:{pixel:['11px','14px'],'pixel-2x':['22px','22px']}}}}`;
-  return (
-    <html lang="en">
-      <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
-        <title>{title}</title>
-        <script src="https://cdn.tailwindcss.com" />
-        <script dangerouslySetInnerHTML={{ __html: tailwindConfig }} />
-        <link
-          rel="preload"
-          href="/fonts/DepartureMono-Regular.woff2"
-          as="font"
-          type="font/woff2"
-          crossOrigin="anonymous"
-        />
-        <style
-          dangerouslySetInnerHTML={{
-            __html: `@font-face{font-family:"Departure Mono";src:url("/fonts/DepartureMono-Regular.woff2") format("woff2"),url("/fonts/DepartureMono-Regular.woff") format("woff"),url("/fonts/DepartureMono-Regular.otf") format("opentype");font-display:swap;font-feature-settings:"locl"} *{font-family:"Departure Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace} html{font-synthesis:none;text-rendering:geometricPrecision;-webkit-font-smoothing:none;-moz-osx-font-smoothing:unset;font-smooth:never;image-rendering:pixelated} *{font-variant-ligatures:none;font-feature-settings:"locl"} .text-pixel-2x{font-size:11px!important;line-height:14px!important;display:inline-block;transform:scale(2);transform-origin:left center;image-rendering:pixelated} h1.text-pixel-2x,h2.text-pixel-2x{display:block;transform-origin:left top;margin-bottom:11px} .hdr-logo svg{height:22px;width:auto;display:block}`,
-          }}
-        />
-        <script dangerouslySetInnerHTML={{ __html: renderAnalyticsInner() }} />
-        <script dangerouslySetInnerHTML={{ __html: renderMetaPixelInner() }} />
-        {(() => {
-          const hydrateSrc = process.env.DRAWBANG_ASSET_VERSION
-            ? assetUrl("/assets/hydrate-v2-design.js")
-            : "/src/hydrate-v2-design.tsx";
-          return <script type="module" src={hydrateSrc} />;
-        })()}
-      </head>
-      <body className="bg-white text-black font-mono antialiased">
-        <BrutalHeader />
-        <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
-          <div className="flex flex-col gap-6 sm:gap-8">
-            {/* Page intro — mobile-first: stacked, then row on sm */}
-            <header className="flex flex-col gap-3 border border-black rounded-[4px] bg-white p-4 sm:p-6">
-              <h1 className="text-pixel-2x sm:text-pixel-2x font-normal">
-                Design system — brutalist
-              </h1>
-              <p className="text-pixel text-zinc-600 font-mono">
-                Mobile-first, mono everywhere, 1px round borders, accent{" "}
-                <span className="inline-flex items-center gap-2">
-                  <span className="inline-block h-3 w-3 rounded-[4px] border border-black bg-[#00ffcc]" />
-                  #00ffcc
-                </span>{" "}
-                — tokens → Tailwind → kitchen sink. Old{" "}
-                <code className="bg-zinc-100 border border-black rounded-[4px] px-1">/design</code>{" "}
-                stays on{" "}
-                <code className="bg-zinc-100 border border-black rounded-[4px] px-1">
-                  chrome.css
-                </code>
-                .
-              </p>
-              <p className="text-pixel text-zinc-500">
-                Playground for #1 — prove one component model before touching <code>/</code>,{" "}
-                <code>/d/*</code>, <code>/u/*</code>.
-              </p>
-            </header>
-            <main className="flex flex-col gap-8 sm:gap-10">{children}</main>
-            <BrutalFooter repoUrl={repoUrl} />
-          </div>
-        </div>
-        <script src={assetUrl("/flash.js")} />
-        <script src={assetUrl("/chrome-toggle.js")} />
-        <script src={assetUrl("/chrome-identity.js")} />
-        <script src={assetUrl("/hydrate.js")} />
-      </body>
-    </html>
-  );
-}
-
-function BrutalHeader() {
-  return (
-    <header className="sticky top-0 z-10 border-b border-black bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80">
-      <div className="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-3 sm:px-6 lg:px-8">
-        <a
-          href="/"
-          aria-label="Draw! home"
-          className="hdr-logo inline-flex items-center hover:opacity-80"
-          dangerouslySetInnerHTML={{ __html: LOGO_SVG }}
-        />
-        <nav className="hidden sm:flex items-center gap-2 text-pixel">
-          <a
-            href="/products"
-            className="rounded-[4px] border border-black bg-white px-3 py-1.5 hover:bg-zinc-50"
-          >
-            Products
-          </a>
-          <a
-            href="/draw"
-            className="rounded-[4px] border border-black bg-[#00ffcc] px-3 py-1.5 font-medium hover:bg-[#00ffcc]/90"
-          >
-            New drawing
-          </a>
-          <a
-            href="/login"
-            className="rounded-[4px] border border-black bg-white px-3 py-1.5 hover:bg-zinc-50"
-          >
-            Sign in
-          </a>
-        </nav>
-        <a
-          href="/draw"
-          className="sm:hidden inline-flex items-center rounded-[4px] border border-black bg-[#00ffcc] px-3 py-2 text-pixel font-medium"
-        >
-          Draw
-        </a>
-      </div>
-    </header>
-  );
-}
-
-function BrutalFooter({ repoUrl }: { repoUrl: string }) {
-  return (
-    <footer className="border border-black rounded-[4px] bg-white p-4 text-pixel text-zinc-600 flex flex-col sm:flex-row gap-2 sm:items-center sm:justify-between">
-      <span className="font-mono">
-        Draw! — brutalist, mono, 1px round •{" "}
-        <a href="/privacy" className="underline decoration-black underline-offset-2">
-          Privacy
-        </a>{" "}
-        •{" "}
-        <a
-          href="https://github.com/potomak/drawbang/issues/new?labels=feedback"
-          className="underline decoration-black underline-offset-2"
-        >
-          Feedback
-        </a>
-      </span>
-      <a
-        href={repoUrl}
-        className="rounded-[4px] border border-black bg-zinc-50 px-2 py-1 font-mono text-pixel hover:bg-white"
-      >
-        {repoUrl.replace("https://", "")}
-      </a>
-    </footer>
-  );
-}
 
 function Section({
   title,
@@ -258,8 +101,28 @@ export default function renderDesignV2(v: DesignV2View): string {
     <BrutalShell
       title="Draw! · Design system — v2 (React + Tailwind brutalist)"
       repoUrl={v.repo_url}
+      variant="original"
+      includeHydrate
     >
-      {/* Mobile-first grid: 1 col on mobile, 2 on sm, 3 on lg */}
+      {/* Page intro — now part of children since BrutalShell is shared chrome */}
+      <header className="flex flex-col gap-3 border border-black rounded-[4px] bg-white p-4 sm:p-6">
+        <h1 className="text-pixel-2x sm:text-pixel-2x font-normal">Design system — brutalist</h1>
+        <p className="text-pixel text-zinc-600 font-mono">
+          Mobile-first, mono everywhere, 1px round borders, accent{" "}
+          <span className="inline-flex items-center gap-2">
+            <span className="inline-block h-3 w-3 rounded-[4px] border border-black bg-[#00ffcc]" />
+            #00ffcc
+          </span>{" "}
+          — tokens → Tailwind → kitchen sink. Old{" "}
+          <code className="bg-zinc-100 border border-black rounded-[4px] px-1">/design</code> stays on{" "}
+          <code className="bg-zinc-100 border border-black rounded-[4px] px-1">chrome.css</code>.
+        </p>
+        <p className="text-pixel text-zinc-500">
+          Playground for #1 — prove one component model before touching <code>/</code>, <code>/d/*</code>,{" "}
+          <code>/u/*</code>.
+        </p>
+      </header>
+
       <Section
         title="Color — brutalist"
         lede="White / black / #00ffcc only. No gradients, no shadows."
@@ -410,8 +273,8 @@ export default function renderDesignV2(v: DesignV2View): string {
       </Section>
 
       <div className="rounded-[4px] border border-black bg-[#00ffcc]/20 p-3 font-mono text-pixel sm:text-pixel">
-        <span className="font-bold">Mobile-first check:</span> resize to 390px — grid collapses to 1
-        col, buttons stay ≥44px, header shows “Draw” CTA, no horizontal scroll.
+        <span className="font-bold">Mobile-first check:</span> resize to 390px — grid collapses to 1 col,
+        buttons stay ≥44px, header shows “Draw” CTA, no horizontal scroll.
       </div>
     </BrutalShell>
   );


### PR DESCRIPTION
Extracts the common brutalist shell (html/head, Tailwind CDN + Departure Mono, .text-pixel-2x handling, BrutalHeader/Footer, analytics + hydrate) into `lib/templates/brutal-shell.tsx`.

- `BrutalShell` takes `variant="original"|"fixed"|"noscale"`, `includeHydrate`, `header`/`footer` and `extraHead`/`extraBody` so both `/v2/design` and `/v2/design/viewport_debug` reuse the same chrome.
- `design-v2.tsx` now imports `BrutalShell` and only defines page-specific Sections/Buttons — intro header moved to children (was inside shell). Keeps `variant="original"` + `includeHydrate` and `22px` logo fix.
- `viewport_debug` now uses `BrutalShell variant={...}` with custom header (22px vs 16px comparison) and debug badge — no duplicated Tailwind/analytics/style constants. Adds `noscale` test (22px `transform:none; font-weight:400`) as you requested, alongside `original` and `fixed`.

Foundation for the next wave of `/v2/*` migrations: new pages can `import { BrutalShell } from './brutal-shell.js'` and get header/footer/analytics/hydrate for free.

Verified: `tsc` 0, `eslint` 0, `vite build` 144k hydrate, `npm test` 854 pass.