### PR TITLE
feat(v2): /v2/d/:id Tailwind brutalist drawing page with 10x pixel sizing

### DIFF
--- a/infra/aws/template.yaml
+++ b/infra/aws/template.yaml
@@ -404,6 +404,14 @@ Resources:
             CachedMethods: [GET, HEAD]
             Compress: true
             CachePolicyId: !Ref DynamicCachePolicy
+          # /v2/d/<id> — Tailwind brutalist drawing page (same cache as /d/*).
+          - PathPattern: /v2/d/*
+            TargetOriginId: api
+            ViewerProtocolPolicy: redirect-to-https
+            AllowedMethods: [GET, HEAD]
+            CachedMethods: [GET, HEAD]
+            Compress: true
+            CachePolicyId: !Ref DynamicCachePolicy
           # /products (exact) + /products/p/<N>. Split for the same reason
           # /gallery is — keep wildcards off the asset-prefix space.
           - PathPattern: /products
@@ -1075,6 +1083,12 @@ Resources:
             ApiId: !Ref IngestApi
             Method: ANY
             Path: /v2/design
+        DrawingPageV2:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref IngestApi
+            Method: ANY
+            Path: /v2/d/{id}
         DrawingPage:
           Type: HttpApi
           Properties:

--- a/ingest/render-handlers.ts
+++ b/ingest/render-handlers.ts
@@ -29,6 +29,5 @@ export {
   renderPromptItemsHandler,
 } from "./render/prompts.js";
 export { renderDesignPageHandler } from "./render/design.js";
-export { renderDesignV2PageHandler } from "./render/design-v2.js";
 export { renderDrawingV2PageHandler } from "./render/drawing-v2.js";
 export { renderFeedHandler } from "./render/feed.js";

--- a/ingest/render-handlers.ts
+++ b/ingest/render-handlers.ts
@@ -29,4 +29,6 @@ export {
   renderPromptItemsHandler,
 } from "./render/prompts.js";
 export { renderDesignPageHandler } from "./render/design.js";
+export { renderDesignV2PageHandler } from "./render/design-v2.js";
+export { renderDrawingV2PageHandler } from "./render/drawing-v2.js";
 export { renderFeedHandler } from "./render/feed.js";

--- a/ingest/render-handlers.ts
+++ b/ingest/render-handlers.ts
@@ -29,5 +29,4 @@ export {
   renderPromptItemsHandler,
 } from "./render/prompts.js";
 export { renderDesignPageHandler } from "./render/design.js";
-export { renderDrawingV2PageHandler } from "./render/drawing-v2.js";
 export { renderFeedHandler } from "./render/feed.js";

--- a/ingest/render/drawing-v2.ts
+++ b/ingest/render/drawing-v2.ts
@@ -1,0 +1,74 @@
+import {
+  CC_DRAWING_PAGE,
+  DRAWING_ID_RE,
+  isAnonymousUsername,
+  PER_PAGE,
+} from "../../config/constants.js";
+import renderDrawingV2 from "../../lib/templates/drawing-v2.js";
+import type { RenderHandlersConfig, RenderResponse } from "./shared.js";
+import { itemFromRow, notFound } from "./shared.js";
+import type { DrawingRow, DrawingStore } from "../drawing-store.js";
+
+const ANCESTOR_CHAIN_CAP = 8;
+
+async function loadAncestorChain(
+  store: DrawingStore,
+  row: DrawingRow
+): Promise<{ id: string; id_short: string }[]> {
+  const chain: { id: string; id_short: string }[] = [];
+  const visited = new Set<string>([row.drawing_id]);
+  let parentId = row.parent_id;
+  while (parentId && chain.length < ANCESTOR_CHAIN_CAP && !visited.has(parentId)) {
+    visited.add(parentId);
+    const parent = await store.get(parentId);
+    if (!parent) break;
+    chain.push({ id: parent.drawing_id, id_short: parent.drawing_id.slice(0, 8) });
+    parentId = parent.parent_id;
+  }
+  return chain.reverse();
+}
+
+export async function renderDrawingV2PageHandler(
+  cfg: RenderHandlersConfig,
+  drawing_id: string
+): Promise<RenderResponse> {
+  if (!DRAWING_ID_RE.test(drawing_id)) return notFound(cfg);
+  const row = await cfg.drawingStore.get(drawing_id);
+  if (!row) return notFound(cfg);
+
+  const forks = await cfg.drawingStore.queryForks(drawing_id, {
+    limit: cfg.perPage ?? PER_PAGE,
+  });
+  const ancestors = await loadAncestorChain(cfg.drawingStore, row);
+  const isAnonymous = isAnonymousUsername(row.username);
+  const authorAccount =
+    cfg.userStore && !isAnonymous ? await cfg.userStore.getByUsername(row.username) : null;
+  const body = renderDrawingV2({
+    drawing_id: row.drawing_id,
+    id_short: row.drawing_id.slice(0, 8),
+    created_at: row.created_at,
+    frames: row.frames,
+    size: row.size,
+    parent: row.parent_id
+      ? { parent: row.parent_id, parent_short: row.parent_id.slice(0, 8) }
+      : null,
+    author: isAnonymous
+      ? null
+      : {
+          user_id: row.user_id,
+          username: row.username,
+          profile_picture_drawing_id: authorAccount?.profile_picture_drawing_id ?? null,
+        },
+    forks: forks.items.map(itemFromRow),
+    ancestors,
+    like_count: row.like_count ?? 0,
+    public_base_url: cfg.publicBaseUrl,
+    repo_url: cfg.repoUrl,
+  });
+  return {
+    status: 200,
+    contentType: "text/html; charset=utf-8",
+    cacheControl: CC_DRAWING_PAGE,
+    body,
+  };
+}

--- a/ingest/render/drawing-v2.ts
+++ b/ingest/render/drawing-v2.ts
@@ -44,7 +44,7 @@ export async function renderDrawingV2PageHandler(
   const authorAccount =
     cfg.userStore && !isAnonymous ? await cfg.userStore.getByUsername(row.username) : null;
   const body = renderDrawingV2({
-    drawing_id: row.drawing_id,
+    id: row.drawing_id,
     id_short: row.drawing_id.slice(0, 8),
     created_at: row.created_at,
     frames: row.frames,

--- a/ingest/render/drawing-v2.ts
+++ b/ingest/render/drawing-v2.ts
@@ -30,13 +30,13 @@ async function loadAncestorChain(
 
 export async function renderDrawingV2PageHandler(
   cfg: RenderHandlersConfig,
-  drawing_id: string
+  id: string
 ): Promise<RenderResponse> {
-  if (!DRAWING_ID_RE.test(drawing_id)) return notFound(cfg);
-  const row = await cfg.drawingStore.get(drawing_id);
+  if (!DRAWING_ID_RE.test(id)) return notFound(cfg);
+  const row = await cfg.drawingStore.get(id);
   if (!row) return notFound(cfg);
 
-  const forks = await cfg.drawingStore.queryForks(drawing_id, {
+  const forks = await cfg.drawingStore.queryForks(id, {
     limit: cfg.perPage ?? PER_PAGE,
   });
   const ancestors = await loadAncestorChain(cfg.drawingStore, row);
@@ -49,9 +49,7 @@ export async function renderDrawingV2PageHandler(
     created_at: row.created_at,
     frames: row.frames,
     size: row.size,
-    parent: row.parent_id
-      ? { parent: row.parent_id, parent_short: row.parent_id.slice(0, 8) }
-      : null,
+    parent: row.parent_id ? { id: row.parent_id, id_short: row.parent_id.slice(0, 8) } : null,
     author: isAnonymous
       ? null
       : {

--- a/ingest/routes.ts
+++ b/ingest/routes.ts
@@ -629,6 +629,15 @@ export function createRoutes(deps: RouteDeps): Route[] {
     },
     {
       methods: ["GET"],
+      pattern: new RegExp(`^\\/v2\\/d\\/(${HEX64})$`),
+      auth: "none",
+      handler: async (_req, [id]) => {
+        const { renderDrawingV2PageHandler } = await import("./render/drawing-v2.js");
+        return render(await renderDrawingV2PageHandler(deps.renderConfig, id));
+      },
+    },
+    {
+      methods: ["GET"],
       pattern: new RegExp(`^\\/d\\/(${HEX64})$`),
       auth: "none",
       handler: async (_req, [id]) => render(await renderDrawingPageHandler(deps.renderConfig, id)),

--- a/lib/templates/drawing-v2.tsx
+++ b/lib/templates/drawing-v2.tsx
@@ -11,7 +11,7 @@ import type { GalleryItem } from "./gallery.js";
 // hydration channel to avoid diverging per-page state.
 
 interface DrawingV2View {
-  drawing_id: string;
+  id: string;
   id_short: string;
   created_at: string;
   frames?: number;
@@ -89,8 +89,8 @@ function ProfilePictureV2({
 }
 
 function DrawingV2Page(v: DrawingV2View) {
-  const gif = `/tiles/${v.drawing_id}.gif`;
-  const shareMp4 = `/tiles/${v.drawing_id}-large.mp4`;
+  const gif = `/tiles/${v.id}.gif`;
+  const shareMp4 = `/tiles/${v.id}-large.mp4`;
   const created = formatCreatedAtV2(v.created_at);
   const framesSuffix =
     typeof v.frames === "number" && v.frames > 0
@@ -105,7 +105,7 @@ function DrawingV2Page(v: DrawingV2View) {
         name="description"
         content="Pixel art from Draw! · Create your own at https://pixel.drawbang.com"
       />
-      <link rel="canonical" href={`${v.public_base_url}/d/${v.drawing_id}`} />
+      <link rel="canonical" href={`${v.public_base_url}/d/${v.id}`} />
       <meta property="og:type" content="website" />
       <meta property="og:site_name" content="Draw!" />
       <meta property="og:title" content={`Drawing ${v.id_short}`} />
@@ -113,15 +113,15 @@ function DrawingV2Page(v: DrawingV2View) {
         property="og:description"
         content="Pixel art from Draw! · Create your own pixel art at https://pixel.drawbang.com"
       />
-      <meta property="og:url" content={`${v.public_base_url}/d/${v.drawing_id}`} />
-      <meta property="og:image" content={`${v.public_base_url}/tiles/${v.drawing_id}-large.gif`} />
+      <meta property="og:url" content={`${v.public_base_url}/d/${v.id}`} />
+      <meta property="og:image" content={`${v.public_base_url}/tiles/${v.id}-large.gif`} />
       <meta property="og:image:type" content="image/gif" />
       <meta property="og:image:width" content="960" />
       <meta property="og:image:height" content="960" />
-      <meta property="og:video" content={`${v.public_base_url}/tiles/${v.drawing_id}-large.mp4`} />
+      <meta property="og:video" content={`${v.public_base_url}/tiles/${v.id}-large.mp4`} />
       <meta
         property="og:video:secure_url"
-        content={`${v.public_base_url}/tiles/${v.drawing_id}-large.mp4`}
+        content={`${v.public_base_url}/tiles/${v.id}-large.mp4`}
       />
       <meta property="og:video:type" content="video/mp4" />
       <meta property="og:video:width" content="1080" />
@@ -134,7 +134,7 @@ function DrawingV2Page(v: DrawingV2View) {
     <BrutalShell title={`Draw! · ${v.id_short}`} repoUrl={v.repo_url} extraHead={ogMeta}>
       <main
         data-tile-page
-        data-drawing-id={v.drawing_id}
+        data-drawing-id={v.id}
         data-id-short={v.id_short}
         data-author-username={v.author?.username ?? ""}
         data-public-base-url={v.public_base_url}
@@ -214,7 +214,7 @@ function DrawingV2Page(v: DrawingV2View) {
             <div className="flex flex-col gap-3">
               <div className="flex flex-wrap gap-2">
                 <a
-                  href={`/draw?fork=${v.drawing_id}`}
+                  href={`/draw?fork=${v.id}`}
                   id="dr-fork"
                   className="inline-flex min-h-[44px] items-center justify-center rounded-[4px] border border-black bg-[#00ffcc] px-4 py-2 font-mono text-pixel font-medium hover:bg-[#00ffcc]/90 active:translate-y-px"
                 >
@@ -225,7 +225,7 @@ function DrawingV2Page(v: DrawingV2View) {
                 <button
                   className="inline-flex min-h-[44px] items-center gap-1.5 rounded-[4px] border border-black bg-white px-3 py-2 font-mono text-pixel font-medium hover:bg-zinc-50 active:translate-y-px"
                   type="button"
-                  data-like-target={v.drawing_id}
+                  data-like-target={v.id}
                   aria-pressed="false"
                   aria-label="Like this drawing"
                 >
@@ -248,7 +248,7 @@ function DrawingV2Page(v: DrawingV2View) {
                 <button
                   className="inline-flex min-h-[44px] items-center justify-center rounded-[4px] border border-black bg-white px-3 py-2 font-mono text-pixel hover:bg-zinc-50 active:translate-y-px"
                   type="button"
-                  data-bookmark-target={v.drawing_id}
+                  data-bookmark-target={v.id}
                   aria-pressed="false"
                   aria-label="Bookmark this drawing"
                 >
@@ -266,7 +266,7 @@ function DrawingV2Page(v: DrawingV2View) {
                   </svg>
                 </button>
                 <a
-                  href={`/merch?d=${v.drawing_id}&frame=0`}
+                  href={`/merch?d=${v.id}&frame=0`}
                   id="dr-make-merch"
                   rel="nofollow noreferrer"
                   className="inline-flex min-h-[44px] items-center justify-center rounded-[4px] border border-black bg-white px-4 py-2 font-mono text-pixel font-medium hover:bg-zinc-50 active:translate-y-px"
@@ -308,7 +308,7 @@ function DrawingV2Page(v: DrawingV2View) {
               </div>
               <div className="flex flex-wrap gap-2">
                 <a
-                  href={`https://www.threads.net/intent/post?text=${encodeURIComponent(`Pixel art from Draw! · Drawing ${v.id_short}`)}&url=${encodeURIComponent(`${v.public_base_url}/d/${v.drawing_id}`)}`}
+                  href={`https://www.threads.net/intent/post?text=${encodeURIComponent(`Pixel art from Draw! · Drawing ${v.id_short}`)}&url=${encodeURIComponent(`${v.public_base_url}/d/${v.id}`)}`}
                   target="_blank"
                   rel="nofollow noopener noreferrer"
                   id="dr-share-threads"
@@ -317,7 +317,7 @@ function DrawingV2Page(v: DrawingV2View) {
                   Share to Threads
                 </a>
                 <a
-                  href={`https://www.reddit.com/submit?url=${encodeURIComponent(`${v.public_base_url}/d/${v.drawing_id}`)}&title=${encodeURIComponent(`Pixel art from Draw! · Drawing ${v.id_short}`)}`}
+                  href={`https://www.reddit.com/submit?url=${encodeURIComponent(`${v.public_base_url}/d/${v.id}`)}&title=${encodeURIComponent(`Pixel art from Draw! · Drawing ${v.id_short}`)}`}
                   target="_blank"
                   rel="nofollow noopener noreferrer"
                   id="dr-share-reddit"
@@ -326,7 +326,7 @@ function DrawingV2Page(v: DrawingV2View) {
                   Share to Reddit
                 </a>
                 <a
-                  href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(`${v.public_base_url}/d/${v.drawing_id}`)}&text=${encodeURIComponent(`Pixel art from Draw! · Drawing ${v.id_short}`)}`}
+                  href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(`${v.public_base_url}/d/${v.id}`)}&text=${encodeURIComponent(`Pixel art from Draw! · Drawing ${v.id_short}`)}`}
                   target="_blank"
                   rel="nofollow noopener noreferrer"
                   id="dr-share-x"
@@ -378,7 +378,7 @@ function DrawingV2Page(v: DrawingV2View) {
               ))}
               <li aria-current="page" className="rounded-[4px] border border-black overflow-hidden">
                 <img
-                  src={`/tiles/${v.drawing_id}.gif`}
+                  src={`/tiles/${v.id}.gif`}
                   alt={`this drawing, ${v.id_short}`}
                   width={48}
                   height={48}

--- a/lib/templates/drawing-v2.tsx
+++ b/lib/templates/drawing-v2.tsx
@@ -10,13 +10,13 @@ import type { GalleryItem } from "./gallery.js";
 // once the brutal UI proves stable. For now we keep the single legacy
 // hydration channel to avoid diverging per-page state.
 
-export interface DrawingV2View {
+interface DrawingV2View {
   drawing_id: string;
   id_short: string;
   created_at: string;
   frames?: number;
   size: number;
-  parent: { parent: string; parent_short: string } | null;
+  parent: { id: string; id_short: string } | null;
   author: {
     user_id: string;
     username: string;
@@ -44,7 +44,7 @@ const MONTHS = [
   "December",
 ];
 
-export function formatCreatedAtV2(iso: string): string {
+function formatCreatedAtV2(iso: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
   const month = MONTHS[d.getUTCMonth()];
@@ -62,17 +62,21 @@ function pixelSize(size: number): number {
   return s * 10;
 }
 
-function renderProfilePictureV2(
-  drawing_id: string | null | undefined,
-  username: string,
-  size: number
-): React.ReactNode {
-  if (!drawing_id || !/^[0-9a-f]{64}$/.test(drawing_id)) return null;
+function ProfilePictureV2({
+  drawingId,
+  username,
+  size,
+}: {
+  drawingId: string | null | undefined;
+  username: string;
+  size: number;
+}): React.ReactNode {
+  if (!drawingId || !/^[0-9a-f]{64}$/.test(drawingId)) return null;
   const px = Math.max(8, Math.floor(size));
   return (
     <img
       className="rounded-[4px] border border-black"
-      src={`/tiles/${drawing_id}.gif`}
+      src={`/tiles/${drawingId}.gif`}
       alt={username}
       width={px}
       height={px}
@@ -104,7 +108,7 @@ function DrawingV2Page(v: DrawingV2View) {
       <link rel="canonical" href={`${v.public_base_url}/d/${v.drawing_id}`} />
       <meta property="og:type" content="website" />
       <meta property="og:site_name" content="Draw!" />
-      <meta property="og:title" content={`Tile ID ${v.id_short}`} />
+      <meta property="og:title" content={`Drawing ${v.id_short}`} />
       <meta
         property="og:description"
         content="Pixel art from Draw! · Create your own pixel art at https://pixel.drawbang.com"
@@ -142,7 +146,7 @@ function DrawingV2Page(v: DrawingV2View) {
             <div className="rounded-[4px] border border-black bg-[#f7f7f5] p-2 sm:p-3">
               <img
                 src={gif}
-                alt={`tile ${v.id_short}`}
+                alt={`drawing ${v.id_short}`}
                 width={sizePx}
                 height={sizePx}
                 loading="eager"
@@ -172,11 +176,11 @@ function DrawingV2Page(v: DrawingV2View) {
                       href={`/u/${v.author.username}`}
                       className="inline-flex items-center gap-2 underline decoration-black underline-offset-2 hover:bg-zinc-50 rounded-[4px] px-1 -mx-1"
                     >
-                      {renderProfilePictureV2(
-                        v.author.profile_picture_drawing_id,
-                        v.author.username,
-                        20
-                      )}
+                      <ProfilePictureV2
+                        drawingId={v.author.profile_picture_drawing_id}
+                        username={v.author.username}
+                        size={16}
+                      />
                       {v.author.username}
                     </a>
                   ) : (
@@ -189,10 +193,10 @@ function DrawingV2Page(v: DrawingV2View) {
                   <dt className="min-w-[110px] font-medium text-zinc-600">Remixed from</dt>
                   <dd>
                     <a
-                      href={`/d/${v.parent.parent}`}
+                      href={`/d/${v.parent.id}`}
                       className="underline decoration-black underline-offset-2 hover:bg-zinc-50 rounded-[4px] px-1 -mx-1"
                     >
-                      {v.parent.parent_short}
+                      {v.parent.id_short}
                     </a>
                   </dd>
                 </div>
@@ -304,7 +308,7 @@ function DrawingV2Page(v: DrawingV2View) {
               </div>
               <div className="flex flex-wrap gap-2">
                 <a
-                  href={`https://www.threads.net/intent/post?text=${encodeURIComponent(`Pixel art from Draw! · Tile ID ${v.id_short}`)}&url=${encodeURIComponent(`${v.public_base_url}/d/${v.drawing_id}`)}`}
+                  href={`https://www.threads.net/intent/post?text=${encodeURIComponent(`Pixel art from Draw! · Drawing ${v.id_short}`)}&url=${encodeURIComponent(`${v.public_base_url}/d/${v.drawing_id}`)}`}
                   target="_blank"
                   rel="nofollow noopener noreferrer"
                   id="dr-share-threads"
@@ -313,7 +317,7 @@ function DrawingV2Page(v: DrawingV2View) {
                   Share to Threads
                 </a>
                 <a
-                  href={`https://www.reddit.com/submit?url=${encodeURIComponent(`${v.public_base_url}/d/${v.drawing_id}`)}&title=${encodeURIComponent(`Pixel art from Draw! · Tile ID ${v.id_short}`)}`}
+                  href={`https://www.reddit.com/submit?url=${encodeURIComponent(`${v.public_base_url}/d/${v.drawing_id}`)}&title=${encodeURIComponent(`Pixel art from Draw! · Drawing ${v.id_short}`)}`}
                   target="_blank"
                   rel="nofollow noopener noreferrer"
                   id="dr-share-reddit"
@@ -322,7 +326,7 @@ function DrawingV2Page(v: DrawingV2View) {
                   Share to Reddit
                 </a>
                 <a
-                  href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(`${v.public_base_url}/d/${v.drawing_id}`)}&text=${encodeURIComponent(`Pixel art from Draw! · Tile ID ${v.id_short}`)}`}
+                  href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(`${v.public_base_url}/d/${v.drawing_id}`)}&text=${encodeURIComponent(`Pixel art from Draw! · Drawing ${v.id_short}`)}`}
                   target="_blank"
                   rel="nofollow noopener noreferrer"
                   id="dr-share-x"

--- a/lib/templates/drawing-v2.tsx
+++ b/lib/templates/drawing-v2.tsx
@@ -1,0 +1,430 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { BrutalShell } from "./brutal-shell.js";
+import type { GalleryItem } from "./gallery.js";
+
+// /v2/d/<id> — Tailwind brutalist drawing page (Option A: hydrate/like/bookmark
+// stay on the legacy toggle-handler.js + hydrate.js channel).
+// TODO(#298): migrate hydrate/like/bookmark/follow to React islands
+// (hydrated via src/hydrate-v2-drawing.tsx + BrutalShell includeHydrate)
+// once the brutal UI proves stable. For now we keep the single legacy
+// hydration channel to avoid diverging per-page state.
+
+export interface DrawingV2View {
+  drawing_id: string;
+  id_short: string;
+  created_at: string;
+  frames?: number;
+  size: number;
+  parent: { parent: string; parent_short: string } | null;
+  author: {
+    user_id: string;
+    username: string;
+    profile_picture_drawing_id: string | null;
+  } | null;
+  forks?: GalleryItem[];
+  ancestors?: { id: string; id_short: string }[];
+  like_count: number;
+  public_base_url: string;
+  repo_url: string;
+}
+
+const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+export function formatCreatedAtV2(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const month = MONTHS[d.getUTCMonth()];
+  const day = d.getUTCDate();
+  const year = d.getUTCFullYear();
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mm = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${month} ${day}, ${year} · ${hh}:${mm} UTC`;
+}
+
+function pixelSize(size: number): number {
+  // Constant logical pixel size: 1 image pixel = 10 screen pixels.
+  // 8→80, 16→160, 32→320, 64→640. Clamped to viewport via max-w-full.
+  const s = Number.isFinite(size) ? Math.floor(size) : 16;
+  return s * 10;
+}
+
+function renderProfilePictureV2(
+  drawing_id: string | null | undefined,
+  username: string,
+  size: number
+): React.ReactNode {
+  if (!drawing_id || !/^[0-9a-f]{64}$/.test(drawing_id)) return null;
+  const px = Math.max(8, Math.floor(size));
+  return (
+    <img
+      className="rounded-[4px] border border-black"
+      src={`/tiles/${drawing_id}.gif`}
+      alt={username}
+      width={px}
+      height={px}
+      loading="lazy"
+      data-profile-picture-username={username}
+      data-profile-picture-size={String(px)}
+      style={{ imageRendering: "pixelated" as const }}
+    />
+  );
+}
+
+function DrawingV2Page(v: DrawingV2View) {
+  const gif = `/tiles/${v.drawing_id}.gif`;
+  const shareMp4 = `/tiles/${v.drawing_id}-large.mp4`;
+  const created = formatCreatedAtV2(v.created_at);
+  const framesSuffix =
+    typeof v.frames === "number" && v.frames > 0
+      ? ` · ${v.frames} ${v.frames === 1 ? "frame" : "frames"}`
+      : "";
+  const sizePx = pixelSize(v.size);
+  const forks = v.forks ?? [];
+  const ancestors = v.ancestors ?? [];
+  const ogMeta = (
+    <>
+      <meta
+        name="description"
+        content="Pixel art from Draw! · Create your own at https://pixel.drawbang.com"
+      />
+      <link rel="canonical" href={`${v.public_base_url}/d/${v.drawing_id}`} />
+      <meta property="og:type" content="website" />
+      <meta property="og:site_name" content="Draw!" />
+      <meta property="og:title" content={`Tile ID ${v.id_short}`} />
+      <meta
+        property="og:description"
+        content="Pixel art from Draw! · Create your own pixel art at https://pixel.drawbang.com"
+      />
+      <meta property="og:url" content={`${v.public_base_url}/d/${v.drawing_id}`} />
+      <meta property="og:image" content={`${v.public_base_url}/tiles/${v.drawing_id}-large.gif`} />
+      <meta property="og:image:type" content="image/gif" />
+      <meta property="og:image:width" content="960" />
+      <meta property="og:image:height" content="960" />
+      <meta property="og:video" content={`${v.public_base_url}/tiles/${v.drawing_id}-large.mp4`} />
+      <meta
+        property="og:video:secure_url"
+        content={`${v.public_base_url}/tiles/${v.drawing_id}-large.mp4`}
+      />
+      <meta property="og:video:type" content="video/mp4" />
+      <meta property="og:video:width" content="1080" />
+      <meta property="og:video:height" content="1080" />
+      <meta name="twitter:card" content="summary_large_image" />
+    </>
+  );
+
+  return (
+    <BrutalShell title={`Draw! · ${v.id_short}`} repoUrl={v.repo_url} extraHead={ogMeta}>
+      <main
+        data-tile-page
+        data-drawing-id={v.drawing_id}
+        data-id-short={v.id_short}
+        data-author-username={v.author?.username ?? ""}
+        data-public-base-url={v.public_base_url}
+        className="flex flex-col gap-6 sm:gap-8"
+      >
+        {/* Top: art + meta — stacked on mobile, side-by-side on lg */}
+        <section className="flex flex-col gap-6 lg:flex-row lg:gap-8">
+          <div className="flex justify-center lg:justify-start">
+            <div className="rounded-[4px] border border-black bg-[#f7f7f5] p-2 sm:p-3">
+              <img
+                src={gif}
+                alt={`tile ${v.id_short}`}
+                width={sizePx}
+                height={sizePx}
+                loading="eager"
+                className="block max-w-full"
+                style={{ width: sizePx, height: sizePx, imageRendering: "pixelated" as const }}
+              />
+            </div>
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col gap-4">
+            <dl className="flex flex-col gap-3 rounded-[4px] border border-black bg-white p-4 sm:p-5 font-mono text-pixel">
+              <div className="flex flex-col gap-1 sm:flex-row sm:gap-3">
+                <dt className="min-w-[110px] font-medium text-zinc-600">Created</dt>
+                <dd className="min-w-0 break-words">
+                  <time dateTime={v.created_at}>{created}</time>
+                  {framesSuffix}
+                  <span className="text-zinc-500">
+                    {" "}
+                    · {v.size}×{v.size}
+                  </span>
+                </dd>
+              </div>
+              <div className="flex flex-col gap-1 sm:flex-row sm:gap-3 sm:items-center">
+                <dt className="min-w-[110px] font-medium text-zinc-600">Author</dt>
+                <dd className="min-w-0">
+                  {v.author ? (
+                    <a
+                      href={`/u/${v.author.username}`}
+                      className="inline-flex items-center gap-2 underline decoration-black underline-offset-2 hover:bg-zinc-50 rounded-[4px] px-1 -mx-1"
+                    >
+                      {renderProfilePictureV2(
+                        v.author.profile_picture_drawing_id,
+                        v.author.username,
+                        20
+                      )}
+                      {v.author.username}
+                    </a>
+                  ) : (
+                    <span>anonymous</span>
+                  )}
+                </dd>
+              </div>
+              {v.parent && (
+                <div className="flex flex-col gap-1 sm:flex-row sm:gap-3">
+                  <dt className="min-w-[110px] font-medium text-zinc-600">Remixed from</dt>
+                  <dd>
+                    <a
+                      href={`/d/${v.parent.parent}`}
+                      className="underline decoration-black underline-offset-2 hover:bg-zinc-50 rounded-[4px] px-1 -mx-1"
+                    >
+                      {v.parent.parent_short}
+                    </a>
+                  </dd>
+                </div>
+              )}
+              <div className="flex flex-col gap-1 sm:flex-row sm:gap-3">
+                <dt className="min-w-[110px] font-medium text-zinc-600">ID</dt>
+                <dd>
+                  <code className="rounded-[4px] border border-black bg-zinc-50 px-1.5 py-0.5 break-all">
+                    {v.id_short}
+                  </code>
+                </dd>
+              </div>
+            </dl>
+
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-wrap gap-2">
+                <a
+                  href={`/draw?fork=${v.drawing_id}`}
+                  id="dr-fork"
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-[4px] border border-black bg-[#00ffcc] px-4 py-2 font-mono text-pixel font-medium hover:bg-[#00ffcc]/90 active:translate-y-px"
+                >
+                  Remix
+                </a>
+                {/* Like — brutal button but preserves legacy data attrs for hydrate.js/toggle-handler.js.
+                    TODO: migrate to React island (see file header). */}
+                <button
+                  className="inline-flex min-h-[44px] items-center gap-1.5 rounded-[4px] border border-black bg-white px-3 py-2 font-mono text-pixel font-medium hover:bg-zinc-50 active:translate-y-px"
+                  type="button"
+                  data-like-target={v.drawing_id}
+                  aria-pressed="false"
+                  aria-label="Like this drawing"
+                >
+                  <svg
+                    className="like-icon"
+                    viewBox="0 0 24 24"
+                    width={20}
+                    height={20}
+                    aria-hidden="true"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                  >
+                    <path d="M12 21s-7-4.35-7-10a4 4 0 0 1 7-2.65A4 4 0 0 1 19 11c0 5.65-7 10-7 10z" />
+                  </svg>
+                  <span className="like-count" data-like-count>
+                    {v.like_count}
+                  </span>
+                </button>
+                <button
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-[4px] border border-black bg-white px-3 py-2 font-mono text-pixel hover:bg-zinc-50 active:translate-y-px"
+                  type="button"
+                  data-bookmark-target={v.drawing_id}
+                  aria-pressed="false"
+                  aria-label="Bookmark this drawing"
+                >
+                  <svg
+                    className="bookmark-icon"
+                    viewBox="0 0 24 24"
+                    width={18}
+                    height={18}
+                    aria-hidden="true"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                  >
+                    <path d="M6 3h12v18l-6-4-6 4z" />
+                  </svg>
+                </button>
+                <a
+                  href={`/merch?d=${v.drawing_id}&frame=0`}
+                  id="dr-make-merch"
+                  rel="nofollow noreferrer"
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-[4px] border border-black bg-white px-4 py-2 font-mono text-pixel font-medium hover:bg-zinc-50 active:translate-y-px"
+                >
+                  Make merch
+                </a>
+                <button
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-[4px] border border-black bg-white px-4 py-2 font-mono text-pixel hover:bg-zinc-50 active:translate-y-px"
+                  id="dr-set-profile-picture"
+                  type="button"
+                  hidden
+                >
+                  Set as profile picture
+                </button>
+                <button
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-[4px] border border-black bg-white px-4 py-2 font-mono text-pixel hover:bg-zinc-50 active:translate-y-px"
+                  id="dr-copy-link"
+                  type="button"
+                >
+                  Copy link
+                </button>
+                <a
+                  href={gif}
+                  download
+                  id="dr-download-gif"
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-[4px] border border-black bg-white px-4 py-2 font-mono text-pixel hover:bg-zinc-50 active:translate-y-px"
+                >
+                  Download GIF
+                </a>
+                <a
+                  href={shareMp4}
+                  download
+                  id="dr-download-mp4"
+                  title="Square MP4 with chrome — Instagram-ready"
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-[4px] border border-black bg-white px-4 py-2 font-mono text-pixel hover:bg-zinc-50 active:translate-y-px"
+                >
+                  Download MP4
+                </a>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <a
+                  href={`https://www.threads.net/intent/post?text=${encodeURIComponent(`Pixel art from Draw! · Tile ID ${v.id_short}`)}&url=${encodeURIComponent(`${v.public_base_url}/d/${v.drawing_id}`)}`}
+                  target="_blank"
+                  rel="nofollow noopener noreferrer"
+                  id="dr-share-threads"
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-[4px] border border-black bg-white px-3 py-2 font-mono text-pixel hover:bg-zinc-50 active:translate-y-px"
+                >
+                  Share to Threads
+                </a>
+                <a
+                  href={`https://www.reddit.com/submit?url=${encodeURIComponent(`${v.public_base_url}/d/${v.drawing_id}`)}&title=${encodeURIComponent(`Pixel art from Draw! · Tile ID ${v.id_short}`)}`}
+                  target="_blank"
+                  rel="nofollow noopener noreferrer"
+                  id="dr-share-reddit"
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-[4px] border border-black bg-white px-3 py-2 font-mono text-pixel hover:bg-zinc-50 active:translate-y-px"
+                >
+                  Share to Reddit
+                </a>
+                <a
+                  href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(`${v.public_base_url}/d/${v.drawing_id}`)}&text=${encodeURIComponent(`Pixel art from Draw! · Tile ID ${v.id_short}`)}`}
+                  target="_blank"
+                  rel="nofollow noopener noreferrer"
+                  id="dr-share-x"
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-[4px] border border-black bg-white px-3 py-2 font-mono text-pixel hover:bg-zinc-50 active:translate-y-px"
+                >
+                  Share to X
+                </a>
+                <button
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-[4px] border border-black bg-white px-3 py-2 font-mono text-pixel hover:bg-zinc-50 active:translate-y-px"
+                  id="dr-copy-embed"
+                  type="button"
+                >
+                  Copy embed code
+                </button>
+                <button
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-[4px] border border-black bg-white px-3 py-2 font-mono text-pixel hover:bg-zinc-50 active:translate-y-px"
+                  id="dr-share"
+                  type="button"
+                  hidden
+                >
+                  Share…
+                </button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {ancestors.length > 0 && (
+          <section className="flex flex-col gap-3 rounded-[4px] border border-black bg-white p-4 sm:p-5">
+            <p className="font-mono text-pixel font-medium">Remix chain</p>
+            <ol className="flex flex-wrap gap-2">
+              {ancestors.map((a) => (
+                <li key={a.id}>
+                  <a
+                    href={`/d/${a.id}`}
+                    aria-label={`Drawing ${a.id_short}`}
+                    className="block rounded-[4px] border border-black overflow-hidden hover:opacity-80"
+                  >
+                    <img
+                      src={`/tiles/${a.id}.gif`}
+                      alt={`drawing ${a.id_short}`}
+                      width={48}
+                      height={48}
+                      loading="lazy"
+                      style={{ imageRendering: "pixelated" as const }}
+                    />
+                  </a>
+                </li>
+              ))}
+              <li aria-current="page" className="rounded-[4px] border border-black overflow-hidden">
+                <img
+                  src={`/tiles/${v.drawing_id}.gif`}
+                  alt={`this drawing, ${v.id_short}`}
+                  width={48}
+                  height={48}
+                  style={{ imageRendering: "pixelated" as const }}
+                />
+              </li>
+            </ol>
+          </section>
+        )}
+
+        {forks.length > 0 && (
+          <section className="flex flex-col gap-3 rounded-[4px] border border-black bg-white p-4 sm:p-5">
+            <p className="font-mono text-pixel font-medium">Remixes · {forks.length}</p>
+            <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
+              {forks.map((f) => (
+                <li key={f.id}>
+                  <a
+                    href={f.href ?? `/d/${f.id}`}
+                    aria-label={f.id_short}
+                    className="block rounded-[4px] border border-black overflow-hidden bg-[#f7f7f5] hover:opacity-80"
+                  >
+                    <img
+                      src={f.thumb ?? `/tiles/${f.id}.gif`}
+                      alt=""
+                      width={128}
+                      height={128}
+                      loading="lazy"
+                      className="w-full h-auto aspect-square"
+                      style={{ imageRendering: "pixelated" as const }}
+                    />
+                  </a>
+                  {f.created_at && (
+                    <time
+                      dateTime={f.created_at}
+                      className="mt-1 block font-mono text-pixel text-zinc-600"
+                    >
+                      {formatCreatedAtV2(f.created_at).split(" · ")[0]}
+                    </time>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </main>
+    </BrutalShell>
+  );
+}
+
+export default function renderDrawingV2(v: DrawingV2View): string {
+  const html = renderToStaticMarkup(<DrawingV2Page {...v} />);
+  return `<!doctype html>\n${html}`;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,7 @@ const DEV_PROXY_PATHS = [
   "/backfill",
   "/design",
   "/v2/design",
+  "^/v2/d/.*",
   "/drawings",
   "/feed.rss",
   "/feed/items",


### PR DESCRIPTION
Stack: `master 4a56763` → `chore/v2-drawing 7cdcfe9`.

**What:**
- `GET /v2/d/:id` — React + `BrutalShell` + Tailwind brutalist (same tokens as `/v2/design`), **not** legacy `chrome.css`/`gallery-v2.css`.
- **Constant pixel size:** `1 image pixel = 10 screen pixels` → `8→80, 16→160, 32→320, 64→640` (`width`/`height` + `style width/height` + `max-w-full` + `image-rendering:pixelated`), fixes legacy fixed `320×320`.
- **Option A (as requested):** keeps legacy `static/hydrate.js` + `toggle-handler.js` + `like.js`/`bookmark.js` via `data-like-target`/`data-bookmark-target` (verified `data-like-target` + `max-w-full` in render). Leaves migration note:
  > `TODO(#298): migrate hydrate/like/bookmark/follow to React islands (src/hydrate-v2-drawing.tsx + BrutalShell includeHydrate)` — file header `lib/templates/drawing-v2.tsx:6`.

**How:**
- `lib/templates/drawing-v2.tsx` — brutal cards, `dl` meta (Created + size, Author, Remixed-from, ID), actions (Remix primary `#00ffcc`, like/bookmark, merch, copy/download/share), chain + forks grids.
- `ingest/render/drawing-v2.ts` — mirrors `ingest/render/drawing.ts` (GSI3 forks + ancestor chain cap 8, anonymous handling) but passes `row.size` → template; `CC_DRAWING_PAGE`.
- `ingest/routes.ts` — new `^/v2/d/([0-9a-f]{64})$` (`auth:none`, lazy `import("./render/drawing-v2.js")`), `render-handlers.ts` barrel.
- `infra/aws/template.yaml` — `Events: /v2/d/{id}` + `CacheBehaviors: /v2/d/*` (same cache as `/d/*`).
- `vite.config.ts` — `DEV_PROXY_PATHS "^/v2/d/.*"` so `:5173 → :8787`.

**Verified:** `tsc -b --noEmit 0`, `eslint 0`, `prettier` on changed files, `npm test 854 pass` (`routes.test.ts 26 pass`), manual `render()` for `8/16/32/64` sizing + like/bookmark attrs + ancestors/forks.

**Prod check after merge:** `GET https://pixel.drawbang.com/v2/d/<64hex>` should show 80/160/320/640 art, like/bookmark hydrate via `/hydrate`, no horizontal scroll (max-w-full), OG tags same as `/d/*`.

**Next:** migrate hydration to islands when brutal `/v2/d` proven, then `/v2/u/:username`.

Related: #298.