### PR TITLE
fix(v2/d): prevent art stretch on lg — align flex row to start

### DIFF
--- a/lib/templates/drawing-v2.tsx
+++ b/lib/templates/drawing-v2.tsx
@@ -141,8 +141,8 @@ function DrawingV2Page(v: DrawingV2View) {
         className="flex flex-col gap-6 sm:gap-8"
       >
         {/* Top: art + meta — stacked on mobile, side-by-side on lg */}
-        <section className="flex flex-col gap-6 lg:flex-row lg:gap-8">
-          <div className="flex justify-center lg:justify-start">
+        <section className="flex flex-col gap-6 lg:flex-row lg:items-start lg:gap-8">
+          <div className="flex justify-start self-start">
             <div className="rounded-[4px] border border-black bg-[#f7f7f5] p-2 sm:p-3">
               <img
                 src={gif}


### PR DESCRIPTION
Follow-up to #309 (merged `80331de` = up to `16d3180`).

`lg:flex-row` defaults to `align-items:stretch`, so the left art well stretched to the height of the right meta+actions column — a `16×16 → 160px` measured taller than `160`.

Change in `lib/templates/drawing-v2.tsx:144-145`: add `lg:items-start` on the row and `self-start` on the art wrapper so the `80/160/320/640` stays intrinsic.

Carried from `74f0b62` (pushed after merge, so not in `80331de`). Cherry-picked as `277483c` on `master 80331de`.

Verified: `tsc 0` / `eslint 0` / `prettier` / `854 tests pass`.