### PR TITLE
chore: track browser CDP launch + drive tooling

### DIFF
--- a/docs/browser-cdp.md
+++ b/docs/browser-cdp.md
@@ -1,0 +1,39 @@
+# Browser CDP verification (agent drives user's Chrome)
+
+The agent cannot launch or keep a browser alive (no `&`/backgrounding,
+no `setsid` on macOS). The human launches it; the agent commands it over
+CDP on `localhost:9222`. See `scripts/browser-cdp.js` (the driver).
+
+## Launch (human runs this in their own terminal, macOS)
+
+```sh
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/drawbang-cdp-profile \
+  --no-first-run --no-default-browser-check about:blank
+```
+
+Runs alongside a normal Chrome (separate profile). Leave the window open
+and tell the agent — it verifies with `curl localhost:9222/json/version`.
+
+## Drive (agent runs these)
+
+```sh
+# list tabs (tab ids change on every launch — always re-list)
+curl -s http://localhost:9222/json/list
+# open a fresh tab for the agent (never touch the user's existing tabs)
+bun scripts/browser-cdp.js \
+  ws://localhost:9222/devtools/page/<TAB_ID> \
+  https://pixel.drawbang.com/v2/gallery/lab /tmp/cdp-shot.png
+```
+
+Needs `bun` on PATH (or any WebSocket-capable JS runner — the driver
+only uses `WebSocket`, binary file write, and argv, so porting is trivial).
+
+## Safety
+
+- The instance is the user's real profile surface: the agent only ever
+  operates on tabs it created via `PUT /json/new`, never existing tabs,
+  and never anything logged-in without explicit say-so.
+- Port 9222 gives any local process full control of the instance; the
+  `--user-data-dir` throwaway profile is intentional. Do not log in there.

--- a/scripts/browser-cdp.js
+++ b/scripts/browser-cdp.js
@@ -1,0 +1,45 @@
+// Minimal CDP driver: navigate a page target, wait for load, screenshot.
+// Usage: bun /tmp/cdp.js <wsUrl> <url> <outPng>
+const [wsUrl, url, out] = process.argv.slice(2);
+const ws = new WebSocket(wsUrl);
+let id = 0;
+const pending = new Map();
+function send(method, params = {}) {
+  return new Promise((resolve, reject) => {
+    const msgId = ++id;
+    pending.set(msgId, { resolve, reject });
+    ws.send(JSON.stringify({ id: msgId, method, params }));
+  });
+}
+await new Promise((res, rej) => {
+  ws.onopen = res;
+  ws.onerror = (e) => rej(new Error("ws open failed"));
+});
+ws.onmessage = (ev) => {
+  const m = JSON.parse(ev.data);
+  if (m.id && pending.has(m.id)) {
+    const { resolve, reject } = pending.get(m.id);
+    pending.delete(m.id);
+    if (m.error) reject(new Error(JSON.stringify(m.error)));
+    else resolve(m.result);
+  } else if (m.method === "Page.loadEventFired" && onLoad) {
+    onLoad();
+  }
+};
+let onLoad = null;
+await send("Page.enable");
+const loaded = new Promise((r) => {
+  onLoad = r;
+});
+await send("Page.navigate", { url });
+await Promise.race([loaded, new Promise((r) => setTimeout(r, 15000))]);
+await new Promise((r) => setTimeout(r, 1200));
+const shot = await send("Page.captureScreenshot", { format: "png" });
+await Bun.write(out, Buffer.from(shot.data, "base64"));
+const evaled = await send("Runtime.evaluate", {
+  expression:
+    "document.title + ' | ' + location.href + ' | status:' + (document.querySelector('h1,p')?.textContent?.slice(0,80) || '')",
+  returnByValue: true,
+});
+console.log(evaled.result.value);
+ws.close();


### PR DESCRIPTION
Dev-only verification tooling, no runtime change. Tracks the setup proven today: human launches Chrome with --remote-debugging-port=9222, agent drives it over CDP (navigate + screenshot + evaluate) for visual verification of /v2 work. Adds docs/browser-cdp.md (launch cmd, drive cmds, safety rules) and scripts/browser-cdp.js (verbatim driver already verified end-to-end against prod /v2/gallery/lab). tsc clean.